### PR TITLE
Show level progress up to level 7

### DIFF
--- a/litespeed-cache/admin/tpl/inc/img_optm.level_info.php
+++ b/litespeed-cache/admin/tpl/inc/img_optm.level_info.php
@@ -18,7 +18,7 @@ if ( empty( $optm_summary[ 'level' ] ) ) {
 </p>
 
 <?php
-if ( $optm_summary[ 'level' ] >= 5 || empty( $optm_summary[ '_level_data' ] ) ) {
+if ( $optm_summary[ 'level' ] >= 7 || empty( $optm_summary[ '_level_data' ] ) ) {
 	return ;
 }
 


### PR DESCRIPTION
image optimization page doesn't show the progress bar after level 5 - so people do not know how far they are from level 6 and 7.