### PR TITLE
Update lazyload.lib.js

### DIFF
--- a/litespeed-cache/js/lazyload.lib.js
+++ b/litespeed-cache/js/lazyload.lib.js
@@ -203,7 +203,9 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 			var settings = this._settings;
 			var onIntersection = function onIntersection(entries) {
 				entries.forEach(function (entry) {
-					if (entry.intersectionRatio > 0) {
+					
+					//entry.intersectionRatio is not enough alone because it could be 0 on some intersecting elements
+					if (entry.isIntersecting || entry.intersectionRatio > 0) {
 						var element = entry.target;
 						revealElement(element, settings);
 						_this._observer.unobserve(element);


### PR DESCRIPTION
1. Fix Lazy load not working on iframe embed when user upgrade the version of chrome.
2. entry.intersectionRatio is not enough alone because it could be 0 on some intersecting elements
     ref line 335 : https://github.com/verlok/lazyload/blob/master/dist/lazyload.es2015.js