### PR TITLE
Skip count checking when multisite and use primary site configurations is on

### DIFF
--- a/litespeed-cache/inc/config.class.php
+++ b/litespeed-cache/inc/config.class.php
@@ -514,7 +514,7 @@ class LiteSpeed_Cache_Config extends LiteSpeed_Cache_Const
 	public function plugin_upgrade()
 	{
 		$default_options = $this->get_default_options() ;
-        $site_options = get_site_option( self::OPTION_NAME ) ;
+        $site_options = $this->get_site_options();
         
         // Skip count check if Use Primary Site Configurations is on
 		if (

--- a/litespeed-cache/inc/config.class.php
+++ b/litespeed-cache/inc/config.class.php
@@ -514,8 +514,16 @@ class LiteSpeed_Cache_Config extends LiteSpeed_Cache_Const
 	public function plugin_upgrade()
 	{
 		$default_options = $this->get_default_options() ;
-
-		if ( $this->options[ self::OPID_VERSION ] == $default_options[ self::OPID_VERSION ] && count( $default_options ) == count( $this->options ) ) {
+        $site_options = get_site_option( self::OPTION_NAME ) ;
+        
+        // Skip count check if Use Primary Site Configurations is on
+		if (
+			$this->options[ self::OPID_VERSION ] == $default_options[ self::OPID_VERSION ] &&
+			(
+				!empty ( $site_options[ self::NETWORK_OPID_USE_PRIMARY ] ) ||
+				count( $default_options ) == count( $this->options )
+			)
+		) {
 			return ;
 		}
 


### PR DESCRIPTION
plugin_upgrade() will keep run purge_all() when use primary site configurations is on because 

`count( $default_options ) == count( $this->options )`

always return false.

Adding 

`!empty ( $site_options[ self::NETWORK_OPID_USE_PRIMARY ] )`

to check if use primary site configurations are on to skip the count check.