### PR TITLE
remove_query_strings() regex set remove until next & sign

### DIFF
--- a/litespeed-cache/inc/optimize.class.php
+++ b/litespeed-cache/inc/optimize.class.php
@@ -291,7 +291,7 @@ class LiteSpeed_Cache_Optimize
 	public function remove_query_strings( $src )
 	{
 		if ( strpos( $src, 'ver=' ) !== false ) {
-			$src = preg_replace( '#[&\?]+(ver=([\w\-\.]+))#i', '', $src ) ;
+			$src = preg_replace( '#[&\?]+(ver=([^&]+))#i', '', $src ) ;
 		}
 		return $src ;
 	}


### PR DESCRIPTION
Prevent error causing by `+` sign on the query string

`e.g.: https://example.com/test.js?ver=1.2.3+pro3.4.5`

Remove all the character until next `&` sign