### PR TITLE
Fix/ols cookies offset

### DIFF
--- a/litespeed-cache/admin/tpl/setting/settings_inc.login_cookie.php
+++ b/litespeed-cache/admin/tpl/setting/settings_inc.login_cookie.php
@@ -30,8 +30,13 @@ if ( ! defined( 'WPINC' ) ) die ;
 					. ' ' . __('The cache needs to distinguish who is logged into which WordPress site in order to cache correctly.', 'litespeed-cache')
 				. '</p>';
 
+            $cookie_offset = 0;
+			if ( LITESPEED_SERVER_TYPE === 'LITESPEED_SERVER_OLS' ) {
+				$cookie_offset = 1;
+			}
+
 			$cookie_rule = LiteSpeed_Cache_Admin_Rules::get_instance()->get_rewrite_rule_login_cookie();
-			if ( $cookie_rule && substr($cookie_rule, 0, 11) !== 'Cache-Vary:' ){
+			if ( $cookie_rule && substr($cookie_rule, 0, 11 + $cookie_offset) !== 'Cache-Vary:' ){
 				echo '<div class="litespeed-callout-danger">'
 						. sprintf(__('Error: invalid login cookie. Please check the %s file', 'litespeed-cache'), '.htaccess')
 					. '</div>';
@@ -45,7 +50,7 @@ if ( ! defined( 'WPINC' ) ) die ;
 						. '</div>';
 				}
 				else{
-					$cookie_rule = substr($cookie_rule, 11);
+					$cookie_rule = substr($cookie_rule, 11 + $cookie_offset);
 					$cookie_arr = explode(',', $cookie_rule);
 					if(!in_array($_options[$id], $cookie_arr)) {
 						echo '<div class="litespeed-callout-warning">' .

--- a/litespeed-cache/admin/tpl/setting/settings_inc.login_cookie.php
+++ b/litespeed-cache/admin/tpl/setting/settings_inc.login_cookie.php
@@ -30,10 +30,10 @@ if ( ! defined( 'WPINC' ) ) die ;
 					. ' ' . __('The cache needs to distinguish who is logged into which WordPress site in order to cache correctly.', 'litespeed-cache')
 				. '</p>';
 
-            $cookie_offset = 0;
-			if ( LITESPEED_SERVER_TYPE === 'LITESPEED_SERVER_OLS' ) {
-				$cookie_offset = 1;
-			}
+            $cookie_offset = 0 ;
+            if ( LITESPEED_SERVER_TYPE === 'LITESPEED_SERVER_OLS' ) {
+                $cookie_offset = 1 ;
+            }
 
 			$cookie_rule = LiteSpeed_Cache_Admin_Rules::get_instance()->get_rewrite_rule_login_cookie();
 			if ( $cookie_rule && substr($cookie_rule, 0, 11 + $cookie_offset) !== 'Cache-Vary:' ){


### PR DESCRIPTION
On `admin/litespeed-cache-admin-rules.class.php`, will add extra quotes on .htaccess

```
if ( LITESPEED_SERVER_TYPE === 'LITESPEED_SERVER_OLS' ) {
    $env = '"' . $env . '"' ;
}
```

Which cause `The .htaccess login cookie and Database login cookie do not match.` and `Error: invalid login cookie.` always show on Login Cookies section. So adding offset for OLS server to prevent it.
