### PR TITLE
Fix OLS login cookie bug

### DIFF
--- a/litespeed-cache/admin/litespeed-cache-admin-rules.class.php
+++ b/litespeed-cache/admin/litespeed-cache-admin-rules.class.php
@@ -438,12 +438,14 @@ class LiteSpeed_Cache_Admin_Rules
 		if( substr($rule, 0, strlen('RewriteRule .? - [E=')) !== 'RewriteRule .? - [E=' ) {//todo: use regex
 			return false ;
 		}
+		
+		$rule_cookie = substr( $rule, strlen( 'RewriteRule .? - [E=' ), -1 ) ;
 
 		if ( LITESPEED_SERVER_TYPE === 'LITESPEED_SERVER_OLS' ) {
-			return substr($rule, strlen('RewriteRule .? - [E="'), -2) ;
+			return trim( $rule_cookie, '"' ) ;
 		}
-
-		return substr($rule, strlen('RewriteRule .? - [E='), -1) ;
+		
+		return $rule_cookie ;
 	}
 
 	/**

--- a/litespeed-cache/admin/litespeed-cache-admin-rules.class.php
+++ b/litespeed-cache/admin/litespeed-cache-admin-rules.class.php
@@ -439,7 +439,11 @@ class LiteSpeed_Cache_Admin_Rules
 			return false ;
 		}
 
-		return substr($rule, strlen('RewriteRule .? - [E='), -1) ;//todo:user trim('"')
+		if ( LITESPEED_SERVER_TYPE === 'LITESPEED_SERVER_OLS' ) {
+			return substr($rule, strlen('RewriteRule .? - [E="'), -2) ;
+		}
+
+		return substr($rule, strlen('RewriteRule .? - [E='), -1) ;
 	}
 
 	/**


### PR DESCRIPTION
OLS need extra quota string (") on LOGIN COOKIE,

return a correct string from `get_rewrite_rule_login_cookie()` for OLS server.