### PR TITLE
Check object exists before loop

### DIFF
--- a/litespeed-cache/admin/litespeed-cache-admin-settings.class.php
+++ b/litespeed-cache/admin/litespeed-cache-admin-settings.class.php
@@ -1059,12 +1059,14 @@ class LiteSpeed_Cache_Admin_Settings
 		 */
 		$id = LiteSpeed_Cache_Config::ITEM_CRWL_COOKIES ;
 		$cookie_crawlers = array() ;
-		foreach ( $this->_input[ $id ][ 'name' ] as $k => $v ) {
-			if ( ! $v ) {
-				continue ;
-			}
+		if ( isset( $this->_input[ $id ][ 'name' ] ) ) {
+			foreach ( $this->_input[ $id ][ 'name' ] as $k => $v ) {
+				if ( ! $v ) {
+					continue ;
+				}
 
-			$cookie_crawlers[ $v ] = $this->_input[ $id ][ 'vals' ][ $k ] ;
+				$cookie_crawlers[ $v ] = $this->_input[ $id ][ 'vals' ][ $k ] ;
+			}
 		}
 		update_option( $id, $cookie_crawlers ) ;
 


### PR DESCRIPTION
- [Topic] Problem with activation – errors 
- Warning: Invalid argument supplied for foreach() in `/usr/local/lsws/wordpress/html/wp-content/plugins/litespeed-cache/admin/litespeed-cache-admin-settings.class.php on line 1062`
- litespeed-crawler-cookies empty