### PR TITLE
Create hook for checking internal url. Add WPML domains to hook.

### DIFF
--- a/litespeed-cache/inc/utility.class.php
+++ b/litespeed-cache/inc/utility.class.php
@@ -609,7 +609,22 @@ class LiteSpeed_Cache_Utility
 			define( 'LITESPEED_FRONTEND_HOST', parse_url( $home_host, PHP_URL_HOST ) ) ;
 		}
 
-		return $host === LITESPEED_FRONTEND_HOST ;
+		if ( $host === LITESPEED_FRONTEND_HOST ) {
+			return true ;
+		}
+
+		$sub_domains = array() ;
+		$sub_domains = apply_filters( 'litespeed_cache_internal_sub_domains', $sub_domains ) ;
+
+		if ( ! empty( $sub_domains ) ) {
+			foreach ( $sub_domains as $value ) {
+				if ( $host === $value ) {
+					return true ;
+				}
+			}
+		}
+
+		return false ;
 	}
 
 	/**

--- a/litespeed-cache/thirdparty/lscwp-3rd-wpml.cls.php
+++ b/litespeed-cache/thirdparty/lscwp-3rd-wpml.cls.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The Third Party integration with DIVI Theme.
+ * The Third Party integration with WPML.
  *
  * @since		2.9.0
  * @package		LiteSpeed_Cache

--- a/litespeed-cache/thirdparty/lscwp-3rd-wpml.cls.php
+++ b/litespeed-cache/thirdparty/lscwp-3rd-wpml.cls.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * The Third Party integration with DIVI Theme.
+ *
+ * @since		2.9.0
+ * @package		LiteSpeed_Cache
+ * @subpackage	LiteSpeed_Cache/thirdparty
+ * @author		LiteSpeed Technologies <info@litespeedtech.com>
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die() ;
+}
+LiteSpeed_Cache_API::register( 'LiteSpeed_Cache_ThirdParty_Wpml' ) ;
+
+class LiteSpeed_Cache_ThirdParty_Wpml
+{
+	private static $sub_domains = array() ;
+
+	public static function detect()
+	{
+		if ( ! function_exists( 'icl_object_id' ) ) {
+			return ;
+		}
+
+		$wpml_domain = get_option( 'icl_sitepress_settings', array() ) ;
+
+		$setting_exists = isset( $wpml_domain[ 'language_domains' ] )
+			&& ! empty ( $wpml_domain[ 'language_domains' ] )
+			&& is_array ( $wpml_domain[ 'language_domains' ] ) ;
+
+		if ( $setting_exists ) {
+			$wpml_domains = $wpml_domain['language_domains'] ;
+
+			foreach ( $wpml_domains as $lang => $url ) {
+				array_push( self::$sub_domains, $url ) ;
+			}
+
+			add_filter( 'litespeed_cache_internal_sub_domains', 'LiteSpeed_Cache_ThirdParty_Wpml::hook_multi_url' ) ;
+		}
+	}
+
+	public static function hook_multi_url( $value )
+	{
+		if ( ! empty( self::$sub_domains ) ) {
+			$value = array_merge( $value, self::$sub_domains ) ;
+		}
+
+		return $value ;
+	}
+}

--- a/litespeed-cache/thirdparty/lscwp-registry-3rd.php
+++ b/litespeed-cache/thirdparty/lscwp-registry-3rd.php
@@ -31,6 +31,7 @@ $thirdparty_list = array(
 	'avada',
 	'wp-postratings',
 	'divi-theme-builder',
+	'wpml',
 ) ;
 
 foreach ($thirdparty_list as $val) {


### PR DESCRIPTION
Fixing the following issue by default:

https://wordpress.org/support/topic/litespeed-not-working-with-wpml-secondary-domain/
https://wordpress.org/support/topic/wpml-with-subdomains-litespeed-not-aggregating-resources/