### PR TITLE
Support auto pre-set wpdiscuz commen field.

### DIFF
--- a/litespeed-cache/thirdparty/lscwp-3rd-wpdiscuz.cls.php
+++ b/litespeed-cache/thirdparty/lscwp-3rd-wpdiscuz.cls.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * The Third Party integration with Wpdiscuz.
+ *
+ * @since		2.9.5
+ * @package		LiteSpeed_Cache
+ * @subpackage	LiteSpeed_Cache/thirdparty
+ * @author		LiteSpeed Technologies <info@litespeedtech.com>
+ */
+if ( ! defined('ABSPATH') ) {
+	die() ;
+}
+
+LiteSpeed_Cache_API::register( 'LiteSpeed_Cache_ThirdParty_Wpdiscuz' ) ;
+
+class LiteSpeed_Cache_ThirdParty_Wpdiscuz
+{
+	public static function detect()
+	{
+		if ( ! defined( 'WPDISCUZ_DS' ) ) return ;
+
+		LiteSpeed_Cache_ThirdParty_Wpdiscuz::check_commenter() ;
+		add_action( 'wpdiscuz_add_comment', 'LiteSpeed_Cache_ThirdParty_Wpdiscuz::add_comment' ) ;
+
+	}
+
+	public static function add_comment()
+	{
+		LiteSpeed_Cache_Vary::get_instance()->append_commenter() ;
+	}
+
+	public static function check_commenter()
+	{
+		$commentor = wp_get_current_commenter() ;
+
+		if ( strlen( $commentor[ 'comment_author' ] ) > 0 ) {
+			add_filter( 'litespeed_vary_check_commenter_pending', '__return_false' ) ;
+		}
+	}
+}

--- a/litespeed-cache/thirdparty/lscwp-registry-3rd.php
+++ b/litespeed-cache/thirdparty/lscwp-registry-3rd.php
@@ -32,6 +32,7 @@ $thirdparty_list = array(
 	'wp-postratings',
 	'divi-theme-builder',
 	'wpml',
+	'wpdiscuz',
 ) ;
 
 foreach ($thirdparty_list as $val) {


### PR DESCRIPTION
Fixing `[Forum] LSCache doesn’t save data from comment field` issue,
 need to apply after `Support auto pre-set wpdiscuz commen field [Commit: 464308116c98f131c2e9c2856b4c7a3747419b79]`