### PR TITLE
Just turn on comment box json_encode on builder page

### DIFF
--- a/litespeed-cache/thirdparty/lscwp-3rd-divi-theme-builder.cls.php
+++ b/litespeed-cache/thirdparty/lscwp-3rd-divi-theme-builder.cls.php
@@ -19,6 +19,7 @@ class LiteSpeed_Cache_ThirdParty_Divi_Theme_Builder
 	public static function detect()
 	{
 		if ( ! defined( 'ET_CORE' ) ) return ;
+		if ( empty( $_GET['et_fb'] ) ) return ;
         
 		add_action( 'et_fb_before_comments_template', 'LiteSpeed_Cache_ThirdParty_Divi_Theme_Builder::js_comment_box_on' ) ;
 		add_action( 'et_fb_after_comments_template', 'LiteSpeed_Cache_ThirdParty_Divi_Theme_Builder::js_comment_box_off' ) ;


### PR DESCRIPTION
Fix for #410919, `et_fb_before_comments_template` action run on non-builder page, which should not json_encode, add `if ( empty( $_GET['et_fb'] ) ) return ;` to detect is user on builder page.