### PR TITLE
Added DocBlock to JS Defer Exclusion Filter

### DIFF
--- a/litespeed-cache/admin/tpl/setting/settings_cdn.php
+++ b/litespeed-cache/admin/tpl/setting/settings_cdn.php
@@ -181,14 +181,14 @@ $cdn_mapping = $this->config->get_item( LiteSpeed_Cache_Config::ITEM_CDN_MAPPING
 		</td>
 	</tr>
 
-	<tr <?php if ( ! defined( 'LITESPEED_QUIC_CLOUD' ) ) echo 'class="litespeed-hide"' ; ?>>
+	<tr>
 		<th><?php echo __( 'Quic Cloud API', 'litespeed-cache' ) ; ?></th>
 		<td>
 			<?php $this->build_switch( LiteSpeed_Cache_Config::OPT_CDN_QUIC ) ; ?>
 			<div class="litespeed-desc">
 				<?php echo sprintf( __( 'Use %s API functionality.', 'litespeed-cache' ), 'Quic Cloud' ) ; ?>
 
-				<a id='litespeed_modal_href' href="https://quic.cloud" target="_blank">Quic.cloud</a>
+				<a id='litespeed_modal_href' href="https://quic.cloud" target="_blank">Register for free at QUIC.cloud</a>
 
 				<!-- <link rel="stylesheet" href="<?php echo LSWCP_PLUGIN_URL ; ?>css/iziModal.min.css"> -->
 				<!-- <script type="text/javascript" src="<?php echo LSWCP_PLUGIN_URL ; ?>js/iziModal.min.js"></script> -->
@@ -217,7 +217,7 @@ $cdn_mapping = $this->config->get_item( LiteSpeed_Cache_Config::ITEM_CDN_MAPPING
 					<?php $this->build_input( LiteSpeed_Cache_Config::OPT_CDN_QUIC_KEY ) ; ?>
 					<div class="litespeed-desc">
 						<?php echo sprintf( __( 'Your API key is used to access %s APIs.', 'litespeed-cache' ), 'Quic Cloud' ) ; ?>
-						<?php echo sprintf( __( 'Get it from <a %1$s>%2$s</a>.', 'litespeed-cache' ), 'href="https://quic.cloud/dashboard" target="_blank"', 'Quic Cloud' ) ; ?>
+						<?php echo sprintf( __( 'Get it from <a %1$s>%2$s</a>.', 'litespeed-cache' ), 'href="https://my.quic.cloud/dashboard" target="_blank"', 'Quic Cloud' ) ; ?>
 					</div>
 				</div>
 

--- a/litespeed-cache/inc/optimize.class.php
+++ b/litespeed-cache/inc/optimize.class.php
@@ -91,6 +91,15 @@ class LiteSpeed_Cache_Optimize
 		 * @since 1.5
 		 */
 		if ( $this->cfg_js_defer ) {
+			/**
+			 * Filters the name or fragment of any JS file to ignore and load undeferred.
+			 *
+			 * @since 2.9.6
+			 *
+			 * @param LiteSpeed_Cache_Config|array ITEM_OPTM_JS_DEFER_EXC List of JS filenames,
+			 *                                                            paths or fragments to
+			 *                                                            ignore.
+			 */
 			$this->cfg_js_defer_exc = apply_filters( 'litespeed_optm_js_defer_exc', LiteSpeed_Cache_Config::get_instance()->get_item( LiteSpeed_Cache_Config::ITEM_OPTM_JS_DEFER_EXC ) ) ;
 		}
 

--- a/litespeed-cache/inc/utility.class.php
+++ b/litespeed-cache/inc/utility.class.php
@@ -331,7 +331,7 @@ class LiteSpeed_Cache_Utility
 	{
 		$hit = false ;
 		$this_ttl = 0 ;
-		foreach( $haystack as $item ) {
+		foreach( (array) $haystack as $item ) {
 			if ( ! $item ) {
 				continue ;
 			}


### PR DESCRIPTION
Found excessive `Array to string conversion` errors coming from a custom filter that thought the filter parameter was a string.  The errors stopped when the filter parameter was treated as an array.  The DocBlock makes it clear that the `litespeed_optm_js_defer_exc` filter needs an array and not a string.