### PR TITLE
Prevent non array instance cause 500 error

### DIFF
--- a/litespeed-cache/inc/esi.class.php
+++ b/litespeed-cache/inc/esi.class.php
@@ -586,8 +586,12 @@ class LiteSpeed_Cache_ESI
 	 * @param array $args Parameter used to build the widget.
 	 * @return mixed Return false if display through esi, instance otherwise.
 	 */
-	public function sub_widget_block( array $instance, WP_Widget $widget, array $args )
+	public function sub_widget_block( $instance, WP_Widget $widget, array $args )
 	{
+		if ( !is_array( $instance ) ) {
+			return false ;
+		}
+
 		$name = get_class( $widget ) ;
 		if ( ! isset( $instance[ LiteSpeed_Cache_Config::OPTION_NAME ] ) ) {
 			return $instance ;

--- a/litespeed-cache/inc/esi.class.php
+++ b/litespeed-cache/inc/esi.class.php
@@ -282,7 +282,7 @@ class LiteSpeed_Cache_ESI
 			return ;
 		}
 
-		add_filter('widget_display_callback', array($this, 'sub_widget_block'), 0, 3) ;
+	add_filter('widget_display_callback', array($this, 'sub_widget_block'), 0, 3) ;
 
 		// Add admin_bar esi
 		if ( LiteSpeed_Cache_Router::is_logged_in() ) {
@@ -588,8 +588,9 @@ class LiteSpeed_Cache_ESI
 	 */
 	public function sub_widget_block( $instance, WP_Widget $widget, array $args )
 	{
-		if ( !is_array( $instance ) ) {
-			return false ;
+		// #210407
+		if ( ! is_array( $instance ) ) {
+			return $instance ;
 		}
 
 		$name = get_class( $widget ) ;


### PR DESCRIPTION
#210407 - Unexpected 500 error when using the WordPress plugin cache enabled