### PR TITLE
Fix vary group save bug

### DIFF
--- a/litespeed-cache/admin/litespeed-cache-admin-settings.class.php
+++ b/litespeed-cache/admin/litespeed-cache-admin-settings.class.php
@@ -1199,7 +1199,7 @@ class LiteSpeed_Cache_Admin_Settings
 		}
 
 		// Save vary group settings
-		$this->_save_item( LiteSpeed_Cache_Config::VARY_GROUP ) ;
+		$this->_save_item( LiteSpeed_Cache_Config::VARY_GROUP, 'array' ) ;
 	}
 
 	/**

--- a/litespeed-cache/admin/tpl/setting/settings_esi.php
+++ b/litespeed-cache/admin/tpl/setting/settings_esi.php
@@ -78,7 +78,7 @@ if ( ! defined( 'WPINC' ) ) die ;
 					<td class='litespeed-vary-title'><?php echo $title ; ?></td>
 					<td class='litespeed-vary-val'>
 						<input type="text" class="litespeed-input-short"
-							name="<?php echo LiteSpeed_Cache_Config::VARY_GROUP ; ?>[<?php echo $role ; ?>]"
+							name="<?php echo LiteSpeed_Cache_Config::OPTION_NAME ; ?>[<?php echo LiteSpeed_Cache_Config::VARY_GROUP ; ?>][<?php echo $role ; ?>]"
 							value="<?php echo $this->config->in_vary_group( $role ) ; ?>" />
 					</td>
 				</tr>


### PR DESCRIPTION
#637721 - Litespeed WordPress plugin vary

LiteSpeed Cache > Settings > ESI > Vary Group cannot be saved because of the field name doesn't include `litespeed-cache-conf` so the input cannot be loaded by `register_setting`.