### PR TITLE
Pass query string to $_GET before rendering admin bar.

### DIFF
--- a/litespeed-cache/inc/esi.class.php
+++ b/litespeed-cache/inc/esi.class.php
@@ -688,6 +688,17 @@ class LiteSpeed_Cache_ESI
 	 */
 	public function load_admin_bar_block( $params )
 	{
+		if ( ! empty( $params[ 'ref' ] ) ) {
+			$ref = str_replace( '/?', '', $params[ 'ref' ] );
+			parse_str( $ref, $output ) ;
+
+			if ( ! empty( $output ) && is_array( $output ) ) {
+				foreach ( $output as $key => $value ) {
+					$_GET[ $key ] = $value;
+				}
+			}
+		}
+
 		wp_admin_bar_render() ;
 
 		if ( ! LiteSpeed_Cache::config( LiteSpeed_Cache_Config::OPID_ESI_CACHE_ADMBAR ) ) {


### PR DESCRIPTION
Related to #977284 - Litespeed with divi issue, add query string to ESI admin bar for correct rendering.