### PR TITLE
Add query string to $_GET when rendering ESI admin bar

### DIFF
--- a/litespeed-cache/inc/esi.class.php
+++ b/litespeed-cache/inc/esi.class.php
@@ -694,12 +694,14 @@ class LiteSpeed_Cache_ESI
 	{
 
 		if ( ! empty( $params[ 'ref' ] ) ) {
-			$ref = parse_url( $params[ 'ref' ] ) ;
-			parse_str( $ref[ 'query' ], $output ) ;
+			$ref_qs = parse_url( $params[ 'ref' ], PHP_URL_QUERY ) ;
+			if ( ! empty( $ref_qs ) ) {
+				parse_str( $ref_qs, $ref_qs_arr ) ;
 
-			if ( ! empty( $output ) && is_array( $output ) ) {
-				foreach ( $output as $key => $value ) {
-					$_GET[ $key ] = $value ;
+				if ( ! empty( $ref_qs_arr ) ) {
+					foreach ( $ref_qs_arr as $k => $v ) {
+						$_GET[ $k ] = $v ;
+					}
 				}
 			}
 		}

--- a/litespeed-cache/inc/esi.class.php
+++ b/litespeed-cache/inc/esi.class.php
@@ -692,6 +692,18 @@ class LiteSpeed_Cache_ESI
 	 */
 	public function load_admin_bar_block( $params )
 	{
+
+		if ( ! empty( $params[ 'ref' ] ) ) {
+			$ref = parse_url( $params[ 'ref' ] ) ;
+			parse_str( $ref[ 'query' ], $output ) ;
+
+			if ( ! empty( $output ) && is_array( $output ) ) {
+				foreach ( $output as $key => $value ) {
+					$_GET[ $key ] = $value ;
+				}
+			}
+		}
+
 		wp_admin_bar_render() ;
 
 		if ( ! LiteSpeed_Cache::config( LiteSpeed_Cache_Config::OPID_ESI_CACHE_ADMBAR ) ) {


### PR DESCRIPTION
Related to #977284 - Litespeed with DIVI issue, add `query string` to ESI admin bar for correct rendering.