### PR TITLE
Login twice issue

### DIFF
--- a/litespeed-cache/inc/router.class.php
+++ b/litespeed-cache/inc/router.class.php
@@ -214,7 +214,7 @@ class LiteSpeed_Cache_Router
 	 */
 	public static function get_role( $uid = null )
 	{
-		if ( defined( 'LITESPEED_WP_ROLE' ) ) {
+		if ( defined( 'LITESPEED_WP_ROLE' && is_null( $uid ) ) ) {
 			return LITESPEED_WP_ROLE ;
 		}
 


### PR DESCRIPTION
#717223 - Users have to login twice.
#114165 - LS Cache making users login twice
#413338 - Wordpress login issue with Litespeed cache

The reason why login twice bug occurred after 2.9.5 is because of `LiteSpeed_Cache_Mediacan_media()`
will run `LiteSpeed_Cache_Config::get_instance()->in_exclude_optimization_roles()`
which run `LiteSpeed_Cache_Router::get_role()`,

In the get_role call the function cannot get correct uid might because
in_exclude_optimization_rolesis a static call because `LiteSpeed_Cache_Config::get_instance()`,

so when `LiteSpeed_Cache_Vary::finalize_default_vary()` run `get_role($uid)`,
the get_role already cached the role on LITESPEED_WP_ROLE variable and return it directly,
which make finalize_default_vary cannot set vary.

adding check `is_null( $uid )` on get_role can make the call on `finalize_default_vary()`
return a fresh value instead of cached value.