### PR TITLE
Login twice issue, directly return $role if not set.

### DIFF
--- a/litespeed-cache/inc/router.class.php
+++ b/litespeed-cache/inc/router.class.php
@@ -233,6 +233,7 @@ class LiteSpeed_Cache_Router
 		LiteSpeed_Cache_Log::debug( '[Router] get_role: ' . $role ) ;
 
 		if ( ! $role ) {
+			return $role ;
 			// Guest user
 			LiteSpeed_Cache_Log::debug( '[Router] role: guest' ) ;
 


### PR DESCRIPTION
https://wordpress.org/support/topic/login-problem-with-cache-2/

Tested with **AJAX Login and Registration modal popup + inline form**