### PR TITLE
Set our ESI filter as last filter

### DIFF
--- a/litespeed-cache/inc/esi.class.php
+++ b/litespeed-cache/inc/esi.class.php
@@ -73,7 +73,7 @@ class LiteSpeed_Cache_ESI
 	 */
 	public function esi_init()
 	{
-		add_action( 'template_include', 'LiteSpeed_Cache_ESI::esi_template', 100 ) ;
+		add_filter( 'template_include', 'LiteSpeed_Cache_ESI::esi_template', 99999 ) ;
 
 		add_action( 'load-widgets.php', 'LiteSpeed_Cache_Purge::purge_widget' ) ;
 		add_action( 'wp_update_comment_count', 'LiteSpeed_Cache_Purge::purge_comment_widget' ) ;


### PR DESCRIPTION
#289354 - LSCWP: ESI conflict with Enfold theme

on Enfold theme, they have an hook:
```add_filter( 'template_include' , array($this, 'template_include'), 20000);```

which conflicted with our ESI
```add_action( 'template_include', 'LiteSpeed_Cache_ESI::esi_template', 10 ) ;```

because we are setting:
```$_SERVER[ 'REQUEST_URI' ] = $_SERVER[ 'ESI_REFERER' ] ;```

on their template_include() function, they will get the post id, and check is it using their template, if yes will return the full template
```
$post_id = @get_the_ID();
...
if ($this->get_alb_builder_status( $post_id ))
...
return $builder_template;
```

so the layout is duplicated.

one solution is to put our action after their filter.

Also, changing action to filter following by Wordpress.