### PR TITLE
Fix CSS minify memory exhausted error

### DIFF
--- a/litespeed-cache/lib/css_min.class.php
+++ b/litespeed-cache/lib/css_min.class.php
@@ -511,6 +511,8 @@ class Minifier
 
         while (($blockStartPos = strpos($css, '{', $searchOffset)) !== false) {
             $blockEndPos = strpos($css, '}', $blockStartPos);
+            if ( ! $blockEndPos ) throw new \Exception( 'CSS parse error' ) ;
+
             $nextBlockStartPos = strpos($css, '{', $blockStartPos + 1);
             $ret .= substr($css, $substrOffset, $blockStartPos - $substrOffset);
 


### PR DESCRIPTION
https://wordpress.org/support/topic/my-wordpress-sites-several-page-http-500-error/

Preventing an infinity loop if CSS is broken (Missing closing bracket).