### PR TITLE
add null onload handler once it is used

### DIFF
--- a/litespeed-cache/inc/optimize.class.php
+++ b/litespeed-cache/inc/optimize.class.php
@@ -375,7 +375,7 @@ class LiteSpeed_Cache_Optimize
 
 						$snippet = '' ;
 						foreach ( $urls as $url ) {
-							$snippet .= "<link rel='preload' data-asynced='1' data-optimized='2' as='style' onload='this.rel=\"stylesheet\"' href='$url' />" ;
+							$snippet .= "<link rel=\"preload\" data-asynced=\"1\" data-optimized=\"2\" as=\"style\" onload=\"this.onload=null;this.rel='stylesheet'\" href=\"$url\" />";
 						}
 
 						// enqueue combined file first

--- a/litespeed-cache/inc/optimize.class.php
+++ b/litespeed-cache/inc/optimize.class.php
@@ -375,7 +375,7 @@ class LiteSpeed_Cache_Optimize
 
 						$snippet = '' ;
 						foreach ( $urls as $url ) {
-							$snippet .= "<link rel=\"preload\" data-asynced=\"1\" data-optimized=\"2\" as=\"style\" onload=\"this.onload=null;this.rel='stylesheet'\" href=\"$url\" />";
+							$snippet .= "<link rel='preload' data-asynced='1' data-optimized='2' as='style' onload='this.onload=null;this.rel=\"stylesheet\"' href='$url' />" ;
 						}
 
 						// enqueue combined file first


### PR DESCRIPTION
[loadCSS](https://github.com/filamentgroup/loadCSS) recommends nulling the onload handler once it is used since some browsers will occasionally re-call the handler upon switching the rel attribute to the stylesheet.