### PR TITLE
Auto puge for WooCommerce Advanced Bulk Edit plugin.

### DIFF
--- a/litespeed-cache/thirdparty/lscwp-3rd-woocommerce.cls.php
+++ b/litespeed-cache/thirdparty/lscwp-3rd-woocommerce.cls.php
@@ -977,9 +977,9 @@ class LiteSpeed_Cache_ThirdParty_WooCommerce
 
 	public static function bulk_edit_purge()
 	{
-		$type = $_POST[ 'type' ] ;
+		$stock_string_data = $_POST[ 'data' ] ;
 
-		if ( $type !== 'saveproducts' && empty( $_POST[ 'data' ] ) ) return ;
+		if ( $_POST[ 'type' ] !== 'saveproducts' || empty( $stock_string_data ) ) return ;
 
 		/*
 		* admin-ajax form-data structure
@@ -991,15 +991,14 @@ class LiteSpeed_Cache_ThirdParty_WooCommerce
 		*		)
 		*	)
 		*/
-		$stock_string_data = $_POST[ 'data' ] ;
 		$stock_string_arr = array() ;
-		foreach ( $stock_string_data as $stock_key => $stock_value ) {
+		foreach ( $stock_string_data as $stock_value ) {
 			$stock_string_arr = array_merge( $stock_string_arr, explode( '#^#', $stock_value ) ) ;
 		}
 
 		$lscwp_3rd_woocommerce = new LiteSpeed_Cache_ThirdParty_WooCommerce ;
 
-		if ( sizeof( $stock_string_arr ) < 1 ) return ;
+		if ( count( $stock_string_arr ) < 1 ) return ;
 		foreach ( $stock_string_arr as $edited_stock ) {
 			$product_id = strtok( $edited_stock, '$' );
 			$product = wc_get_product( $product_id ) ;


### PR DESCRIPTION
[Asana] Cache is not automatically cleared with woocommerece plugin
https://www.litespeedtech.com/support/forum/threads/cache-is-not-automatically-cleared.17426/

admin-ajax form data sample:
```
type: saveproducts
nonce: afdc96369c
isfirst: 1
data[_regular_price]: 464$###0$###1#^#463$###0$###3#^#462$###0$###5#^#456$###0$###6#^#311$###0$###4
data[_sale_price]: 464$###0$###2#^#463$###0$###4#^#462$###0$###4
columns[_product_permalink]: 170
columns[product_type]: 100
columns[_visibility]: 190
columns[_stock_status]: 80
columns[_stock]: 80
columns[_tax_status]: 80
columns[_featured]: 80
columns[post_status]: 70
columns[post_content]: 250
columns[_sku]: 60
columns[_sale_price]: 80
columns[_regular_price]: 80
columns[product_cat]: 150
columns[_product_image_gallery]: 90
columns[_thumbnail_id]: 80
columns[post_title]: 250
columns[ID]: 60
columns[sel]: 30
filters: 
```