### PR TITLE
V3.0 support phpredis 5

### DIFF
--- a/litespeed-cache/inc/object.cls.php
+++ b/litespeed-cache/inc/object.cls.php
@@ -534,7 +534,12 @@ class LiteSpeed_Cache_Object
 
 		// defined( 'LSCWP_LOG' ) && LiteSpeed_Cache_Log::debug2( '[Object] delete ' . $key ) ;
 
-		$res = $this->_conn->delete( $key ) ;
+		if ( $this->_oc_driver == 'Redis' ) {
+			$res = $this->_conn->del( $key ) ;
+		}
+		else {
+			$res = $this->_conn->delete( $key ) ;
+		}
 
 		return $res ;
 	}


### PR DESCRIPTION
- `delete` used to be an alias of `del` but isn't supposed in clustering, so using `del` makes more sense from a compatibility perspective.