### PR TITLE
By CDN on admin page when adding media for page and post.

### DIFF
--- a/litespeed-cache/inc/router.class.php
+++ b/litespeed-cache/inc/router.class.php
@@ -125,6 +125,18 @@ class LiteSpeed_Cache_Router
 			$can = false ;
 		}
 
+		/**
+		 * Bypass post/page link setting
+		 * @since 2.9.8.5
+		 */
+		if (
+			strpos( $_SERVER[ 'REQUEST_URI' ], 'wp-json/wp/v2/media' ) !== false
+			&& strpos( $_SERVER[ 'HTTP_REFERER' ], 'wp-admin') !== false
+		) {
+			LiteSpeed_Cache_Log::debug( '[Router] CDN bypassed: wp-json on admin page' ) ;
+			$can = false ;
+		}
+
 		$can_final = apply_filters( 'litespeed_can_cdn', $can ) ;
 
 		if ( $can_final != $can ) {


### PR DESCRIPTION
https://wordpress.org/support/topic/image-linking-and-facebook-issues-with-cdn-turned-on/

After wp5 on admin pane, when a user added an image on post or page when CDN turned ON, `Link Setting > Link URL` will retrieve URL from wp-json: `http://example.com/wp-json/wp/v2/media/32?context=edit&_locale=user` which will be written to CDN URL.