### PR TITLE
Add autocomplete off to admin dashboard radio button

### DIFF
--- a/litespeed-cache/admin/litespeed-cache-admin-display.class.php
+++ b/litespeed-cache/admin/litespeed-cache-admin-display.class.php
@@ -911,7 +911,7 @@ class LiteSpeed_Cache_Admin_Display
 
 		$checked = $checked ? ' checked ' : '' ;
 
-		return "<input type='radio' name='". LiteSpeed_Cache_Config::OPTION_NAME . "$id' id='$id_attr' value='$val' $checked /> <label for='$id_attr'>$txt</label>" ;
+		return "<input type='radio' autocomplete='off' name='". LiteSpeed_Cache_Config::OPTION_NAME . "$id' id='$id_attr' value='$val' $checked /> <label for='$id_attr'>$txt</label>" ;
 	}
 
 	/**

--- a/litespeed-cache/admin/tpl/esi_widget_edit.php
+++ b/litespeed-cache/admin/tpl/esi_widget_edit.php
@@ -49,7 +49,7 @@ $display = LiteSpeed_Cache_Admin_Display::get_instance() ;
 				list( $v, $txt ) = $v ;
 				$id_attr = $widget->get_field_id( $id ) . '_' . $v ;
 				$checked = $esi === $v ? 'checked' : '' ;
-				echo "<input type='radio' name='$name' id='$id_attr' value='$v' $checked /> <label for='$id_attr'>$txt</label>" ;
+				echo "<input type='radio' autocomplete='off' name='$name' id='$id_attr' value='$v' $checked /> <label for='$id_attr'>$txt</label>" ;
 			}
 		?>
 

--- a/litespeed-cache/admin/tpl/manage/manage_purge.php
+++ b/litespeed-cache/admin/tpl/manage/manage_purge.php
@@ -173,25 +173,25 @@ if ( ! is_multisite() || is_network_admin() ) {
 		<div class="litespeed-row">
 			<div class="litespeed-switch litespeed-mini">
 				<?php $val = LiteSpeed_Cache_Admin_Display::PURGEBY_CAT;?>
-				<input type="radio" name="<?php echo $_option_field; ?>" id="purgeby_option_category"
+				<input type="radio" autocomplete="off" name="<?php echo $_option_field; ?>" id="purgeby_option_category"
 					value="<?php echo $val; ?>" <?php if( $purgeby_option == $val ) echo 'checked'; ?>
 				/>
 				<label for="purgeby_option_category"><?php echo __('Category', 'litespeed-cache'); ?></label>
 
 				<?php $val = LiteSpeed_Cache_Admin_Display::PURGEBY_PID;?>
-				<input type="radio" name="<?php echo $_option_field; ?>" id="purgeby_option_postid"
+				<input type="radio" autocomplete="off" name="<?php echo $_option_field; ?>" id="purgeby_option_postid"
 					value="<?php echo $val; ?>" <?php if( $purgeby_option == $val ) echo 'checked'; ?>
 				/>
 				<label for="purgeby_option_postid"><?php echo __('Post ID', 'litespeed-cache'); ?></label>
 
 				<?php $val = LiteSpeed_Cache_Admin_Display::PURGEBY_TAG;?>
-				<input type="radio" name="<?php echo $_option_field; ?>" id="purgeby_option_tag"
+				<input type="radio" autocomplete="off" name="<?php echo $_option_field; ?>" id="purgeby_option_tag"
 					value="<?php echo $val; ?>" <?php if( $purgeby_option == $val ) echo 'checked'; ?>
 				/>
 				<label for="purgeby_option_tag"><?php echo __('Tag', 'litespeed-cache'); ?></label>
 
 				<?php $val = LiteSpeed_Cache_Admin_Display::PURGEBY_URL;?>
-				<input type="radio" name="<?php echo $_option_field; ?>" id="purgeby_option_url"
+				<input type="radio" autocomplete="off" name="<?php echo $_option_field; ?>" id="purgeby_option_url"
 					value="<?php echo $val; ?>" <?php if( $purgeby_option == $val ) echo 'checked'; ?>
 				/>
 				<label for="purgeby_option_url"><?php echo __('URL', 'litespeed-cache'); ?></label>

--- a/litespeed-cache/thirdparty/lscwp-3rd-woocommerce.cls.php
+++ b/litespeed-cache/thirdparty/lscwp-3rd-woocommerce.cls.php
@@ -831,7 +831,7 @@ class LiteSpeed_Cache_ThirdParty_WooCommerce
 		foreach ($seloptions as $val => $title) {
 			$checked = $selected_value == $val ? ' checked="checked" ' : '';
 			$update_intval_html .= "<div class='litespeed-radio-vertical-row'>
-										<input type='radio' name='{$option_group}[$id]' id='conf_{$id}_$val' value='$val' $checked />
+										<input type='radio' autocomplete='off' name='{$option_group}[$id]' id='conf_{$id}_$val' value='$val' $checked />
 										<label for='conf_{$id}_$val'>$title</label>
 									</div>" ;
 		}


### PR DESCRIPTION
#288940 - WP Plugin - Bug with radio buttons

Firefox will autosave the radio button state even you reload the page. Try to set it like other browsers.