### PR TITLE
Remove get_queried_object function on taxonomy page_type

### DIFF
--- a/litespeed-cache/inc/utility.class.php
+++ b/litespeed-cache/inc/utility.class.php
@@ -104,7 +104,7 @@ class LiteSpeed_Cache_Utility
 		}
 		elseif ( $wp_query->is_tax ) {
 			$page_type = 'tax' ;
-			$page_type = get_queried_object()->taxonomy ;
+			// $page_type = get_queried_object()->taxonomy ;
 		}
 		elseif ( $wp_query->is_archive ) {
 			if ( $wp_query->is_day ) {


### PR DESCRIPTION
https://wordpress.org/support/topic/php-notice-appearing-frequently/

Duplicated $page_type variable set by get_queried_object function.