### PR TITLE
Add 3rd for AMP page optm and lazyload bypass.

### DIFF
--- a/litespeed-cache/thirdparty/lscwp-3rd-amp-bypass.cls.php
+++ b/litespeed-cache/thirdparty/lscwp-3rd-amp-bypass.cls.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * The Third Party integration with AMP plugin.
+ *
+ * @since		2.9.8.6
+ * @package		LiteSpeed_Cache
+ * @subpackage	LiteSpeed_Cache/thirdparty
+ * @author		LiteSpeed Technologies <info@litespeedtech.com>
+ */
+if ( ! defined('ABSPATH') ) {
+	die() ;
+}
+
+LiteSpeed_Cache_API::hook_init( 'LiteSpeed_Cache_ThirdParty_AMP_Bypass::pre_load' ) ;
+
+class LiteSpeed_Cache_ThirdParty_AMP_Bypass
+{
+	/**
+	 * CSS async will affect AMP result and
+	 * Lazyload will inject JS library which AMP not allowed
+	 * need to force set false before load
+	 *
+	 * @since 2.9.8.6
+	 * @access public
+	 */
+	public static function pre_load()
+	{
+		if ( ! function_exists( 'is_amp_endpoint' ) || ! is_amp_endpoint() ) return ;
+		LiteSpeed_Cache_API::force_option( LiteSpeed_Cache_API::OPID_OPTM_CSS_ASYNC, false ) ;
+		LiteSpeed_Cache_API::force_option( LiteSpeed_Cache_API::OPID_MEDIA_IMG_LAZY, false ) ;
+		LiteSpeed_Cache_API::force_option( LiteSpeed_Cache_API::OPID_MEDIA_IFRAME_LAZY, false ) ;
+	}
+}

--- a/litespeed-cache/thirdparty/lscwp-registry-3rd.php
+++ b/litespeed-cache/thirdparty/lscwp-registry-3rd.php
@@ -34,6 +34,7 @@ $thirdparty_list = array(
 	'wpml',
 	'wpdiscuz',
 	'facetwp',
+	'amp-bypass',
 ) ;
 
 foreach ($thirdparty_list as $val) {


### PR DESCRIPTION
#359748 - Litespeed cache plugin breaks AMP pages
(Typo fix)