### PR TITLE
Fixing amp bypass bug.

### DIFF
--- a/litespeed-cache/thirdparty/lscwp-3rd-amp-bypass.cls.php
+++ b/litespeed-cache/thirdparty/lscwp-3rd-amp-bypass.cls.php
@@ -26,7 +26,8 @@ class LiteSpeed_Cache_ThirdParty_AMP_Bypass
 	 */
 	public static function pre_load()
 	{
-		if ( ! function_exists( 'is_amp_endpoint' ) || ! is_amp_endpoint() ) return ;
+		if ( ! function_exists( 'is_amp_endpoint' ) || is_admin() || ! isset( $_GET[ 'amp' ] ) ) return ;
+
 		LiteSpeed_Cache_API::force_option( LiteSpeed_Cache_API::OPID_OPTM_CSS_ASYNC, false ) ;
 		LiteSpeed_Cache_API::force_option( LiteSpeed_Cache_API::OPID_MEDIA_IMG_LAZY, false ) ;
 		LiteSpeed_Cache_API::force_option( LiteSpeed_Cache_API::OPID_MEDIA_IFRAME_LAZY, false ) ;


### PR DESCRIPTION
Use `function_exists( 'is_amp_endpoint' )` to detect AMP installed.

Mimicking original `is_amp_endpoint()` to check `is_admin` and amp query string by `$_GET` instead of wp_query.

"/amp" will redirect to "?amp".