### PR TITLE
Update PHP requirement to 5.6.

### DIFF
--- a/litespeed-cache.php
+++ b/litespeed-cache.php
@@ -182,8 +182,8 @@ if ( ! function_exists( 'run_litespeed_cache' ) ) {
 	{
 		$version_supported = true ;
 
-		//Check minimum PHP requirements, which is 5.3 at the moment.
-		if ( version_compare( PHP_VERSION, '5.3.0', '<' ) ) {
+		//Check minimum PHP requirements, which is 5.6 at the moment.
+		if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
 			$version_supported = false ;
 		}
 


### PR DESCRIPTION
Cache > 3.0 requires PHP 5.6, due to this file atleast:
https://github.com/litespeedtech/lscache_wp/blob/master/src/task.cls.php

You can see from here, that it fails if PHP version is less than 5.6:
https://3v4l.org/5eQXt#v560

So we update the requirement, to keep it from trying to run and to
fail in PHP version < 5.6.0.