### PR TITLE
Deny access with Apache rewrite rule

### DIFF
--- a/data/.htaccess
+++ b/data/.htaccess
@@ -1,3 +1,7 @@
 Order Deny,Allow
-
 Deny from All
+
+<IfModule LiteSpeed>
+RewriteEngine on
+RewriteRule .* - [F,L]
+</IfModule>


### PR DESCRIPTION
Supports OpenLiteSpeed Web Servers. OLSWS does not support Apache directives in .htaccess files. Apache rewrite rules are supported and thus should be used to properly deny access to the `data/` directory. See this support article for more information: https://openlitespeed.org/kb/access-control/.