### PR TITLE
feat(buffer): add before and after hooks

### DIFF
--- a/src/core.cls.php
+++ b/src/core.cls.php
@@ -382,6 +382,9 @@ class Core extends Instance
 	{
 		$this->_check_is_html( $buffer );
 
+		// Hook to modify buffer before
+		$buffer = apply_filters('litespeed_buffer_before', $buffer);
+
 		// Replace ESI preserved list
 		$buffer = ESI::finalize( $buffer );
 
@@ -435,6 +438,9 @@ class Core extends Instance
 				Debug2::debug( '[Core] JSON Buffer' );
 			}
 		}
+
+		// Hook to modify buffer after
+		$buffer = apply_filters('litespeed_buffer_after', $buffer);
 
 		Debug2::debug( "End response\n--------------------------------------------------------------------------------\n" );
 


### PR DESCRIPTION
# Feature

Add buffer before and after with hooks.


### Examples

#### Remove pingback link
```php
function remove_pingback_link( $content ) {
    return str_replace( '<link rel="pingback" href="https://example.com/xmlrpc.php">', '', $content );
}
add_filter( 'litespeed_buffer_before', 'remove_pingback_link', 0);
```

#### Remove broken style from critical css
```php
function remove_broken_style( $content ) {
    return str_replace( '.content{opacity:0}', '', $content );
}
add_filter( 'litespeed_buffer_after', 'remove_broken_style', 0);
```

#### Append HTML element after logo
```php
function append_html_element( $content ) {
    return str_replace( '<img src="logo.png">', '<img src="logo.png"><div class="custom-slogan">slogan</div>', $content );
}
add_filter( 'litespeed_buffer_after', 'append_html_element', 0);
```