### PR TITLE
Clarify certain services are not provided natively

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -25,7 +25,7 @@ LSCWP supports WordPress Multisite and is compatible with most popular plugins, 
 = General Features =
 
 * Free QUIC.cloud CDN Cache
-* Object Cache (Memcached/LSMCD/Redis)
+* Object Cache (Memcached/LSMCD/Redis) Support<sup>+</sup>
 * Image Optimization (Lossless/Lossy)
 * Minify CSS, JavaScript, and HTML
 * Minify inline CSS/JS
@@ -33,12 +33,12 @@ LSCWP supports WordPress Multisite and is compatible with most popular plugins, 
 * Automatically generate Critical CSS
 * Lazyload images/iframes
 * Responsive Image Placeholders
-* Multiple CDN support
+* Multiple CDN support<sup>+</sup>
 * Load CSS/JS Asynchronously
-* Browser Cache
+* Browser Cache<sup>+</sup>
 * Database Cleaner and Optimizer
 * PageSpeed score optimization
-* OPcode Cache
+* OPcode Cache<sup>+</sup>
 * HTTP/2 Push for CSS/JS (on web servers that support it)
 * DNS Prefetch
 * Cloudflare API
@@ -47,6 +47,8 @@ LSCWP supports WordPress Multisite and is compatible with most popular plugins, 
 * Attractive, easy-to-understand interface
 * WebP image format support
 * Heartbeat control
+
+<sup>+</sup>The service itself is not provided by the LSCache plugin, but the plugin supports this service if it is already in use on your site.
 
 = LiteSpeed Exclusive Features =
 


### PR DESCRIPTION
Certain services are supported but are not provided natively by the plugin. Object Cache, for example, is supported by LSCWP, but it must be installed and enabled at the server level. LSCWP has no control over that aspect.