### PR TITLE
Update esi.nonce.txt

### DIFF
--- a/data/esi.nonce.txt
+++ b/data/esi.nonce.txt
@@ -28,3 +28,6 @@ role_nonce private
 
 # WooCommerce Delivery Area Pro #16843635
 wdap-call-nonce private
+
+# SEOpress Cookie Consent
+seopress_cookies_user_consent_nonce


### PR DESCRIPTION
SEOpress used this function to check the referer for security if Cookie Consent banner is active:
check_ajax_referer( 'seopress_cookies_user_consent_nonce', $_GET['_ajax_nonce'], true );