### PR TITLE
Exclude Stripe JS and more

### DIFF
--- a/data/js_excludes.txt
+++ b/data/js_excludes.txt
@@ -5,6 +5,10 @@
 # JS file URL excludes
 maps-api-ssl.google.com
 stats.wp.com
+js.stripe.com
+userway.org
+google.com/recaptcha
+
 
 # Inline JS excludes
 document.write
@@ -13,3 +17,5 @@ nonce
 gtm
 dataLayer
 adsbygoogle
+js.stripe.com
+google-analytics.com

--- a/data/js_excludes.txt
+++ b/data/js_excludes.txt
@@ -8,7 +8,7 @@ stats.wp.com
 js.stripe.com
 userway
 google.com/recaptcha
-
+maps.googleapis.com
 
 # Inline JS excludes
 document.write

--- a/data/js_excludes.txt
+++ b/data/js_excludes.txt
@@ -6,7 +6,7 @@
 maps-api-ssl.google.com
 stats.wp.com
 js.stripe.com
-userway.org
+userway
 google.com/recaptcha
 
 


### PR DESCRIPTION
Always exclude js.stripe.com to prevent fatal breakage. Also exclude: reCAPTCHA JS, UserWay accessibility widget, and any inline JS that loads a script from google-analytics.com.