### PR TITLE
Adding Post Max Age-logics for Sitemap-gen

### DIFF
--- a/lang/litespeed-cache.pot
+++ b/lang/litespeed-cache.pot
@@ -3237,6 +3237,14 @@ msgstr ""
 msgid "These options will be invalid when using %s."
 msgstr ""
 
+#: tpl/crawler/settings-sitemap.tpl.php:120
+msgid "Posts Max Age"
+msgstr ""
+
+#: tpl/crawler/settings-sitemap.tpl.php:126
+msgid "Posts older than max age (in days), will not be included in the sitemap."
+msgstr ""
+
 #: tpl/crawler/summary.tpl.php:23
 msgid "%d hours"
 msgstr ""

--- a/src/base.cls.php
+++ b/src/base.cls.php
@@ -149,6 +149,7 @@ class Base extends Instance {
 	const O_OPTM_EMOJI_RM 			= 'optm-emoji_rm';
 	const O_OPTM_NOSCRIPT_RM 		= 'optm-noscript_rm';
 	const O_OPTM_GGFONTS_ASYNC 		= 'optm-ggfonts_async';
+	const O_OPTM_RM_COMMENT 		= 'optm-rm_comment';
 	const O_OPTM_EXC_ROLES 			= 'optm-exc_roles';
 	const O_OPTM_CCSS_CON			= 'optm-ccss_con';
 	const O_OPTM_JS_DEFER_EXC 		= 'optm-js_defer_exc';
@@ -230,6 +231,7 @@ class Base extends Instance {
 	const O_CRAWLER_TAGS 			= 'crawler-inc_tags';
 	const O_CRAWLER_EXC_CPT 		= 'crawler-exc_cpt';
 	const O_CRAWLER_ORDER_LINKS 	= 'crawler-order_links';
+	const O_CRAWLER_POST_MAX_AGE 	= 'crawler-post_max_age';
 	const O_CRAWLER_USLEEP 			= 'crawler-usleep';
 	const O_CRAWLER_RUN_DURATION 	= 'crawler-run_duration';
 	const O_CRAWLER_RUN_INTERVAL 	= 'crawler-run_interval';
@@ -442,6 +444,7 @@ class Base extends Instance {
 		self::O_OPTM_EMOJI_RM 			=> false,
 		self::O_OPTM_NOSCRIPT_RM 		=> false,
 		self::O_OPTM_GGFONTS_ASYNC 		=> false,
+		self::O_OPTM_RM_COMMENT 		=> false,
 		self::O_OPTM_EXC_ROLES			=> array(),
 		self::O_OPTM_CCSS_CON			=> '',
 		self::O_OPTM_JS_DEFER_EXC		=> array(),
@@ -515,6 +518,7 @@ class Base extends Instance {
 		self::O_CRAWLER_TAGS 			=> false,
 		self::O_CRAWLER_EXC_CPT 		=> array(),
 		self::O_CRAWLER_ORDER_LINKS 	=> false,
+		self::O_CRAWLER_POST_MAX_AGE    => 0,	
 		self::O_CRAWLER_USLEEP 			=> 0,
 		self::O_CRAWLER_RUN_DURATION 	=> 0,
 		self::O_CRAWLER_RUN_INTERVAL 	=> 0,

--- a/src/crawler-map.cls.php
+++ b/src/crawler-map.cls.php
@@ -533,6 +533,12 @@ class Crawler_Map extends Instance {
 
 		$show_tags = Conf::val( Base::O_CRAWLER_TAGS );
 
+		$post_max_age = Conf::val( Base::O_CRAWLER_POST_MAX_AGE );
+
+		if($post_max_age){
+			$post_max_age = mktime(0, 0, 0, date("m")  , date("d")-$post_max_age, date("Y"));
+		}
+
 		switch ( Conf::val( Base::O_CRAWLER_ORDER_LINKS ) ) {
 			case 1:
 				$orderBy = " ORDER BY post_date ASC";
@@ -576,7 +582,14 @@ class Crawler_Map extends Instance {
 
 			foreach ( $results as $result ){
 				$slug = str_replace( $this->_home_url, '', get_permalink( $result->ID ) );
-				if ( ! in_array($slug, $blacklist) ) {
+
+				$within_allowed_age = true;
+				if($post_max_age){
+					$postDate = strtotime(get_the_date("d-m-Y", $result->ID ));
+					$within_allowed_age = $post_max_age <= $postDate;
+				}
+
+				if ( ! in_array($slug, $blacklist) && $within_allowed_age) {
 					$this->_urls[] = $slug;
 				}
 			}

--- a/tpl/crawler/settings-sitemap.tpl.php
+++ b/tpl/crawler/settings-sitemap.tpl.php
@@ -115,6 +115,18 @@ $this->form_action();
 						<?php echo sprintf( __( 'These options will be invalid when using %s.', 'litespeed-cache' ), '<code>' . __( 'Custom Sitemap', 'litespeed-cache' ) . '</code>' ); ?>
 					</div>
 				</div>
+
+				<div class='litespeed-col-auto'>
+					<h4><?php echo __('Posts Max Age', 'litespeed-cache'); ?></h4>
+					<div class='litespeed-col-auto'>
+						<?php $id = Base::O_CRAWLER_POST_MAX_AGE; ?>
+						<?php $this->build_input( $id, 'litespeed-input-short' ); ?> <?php echo __( 'Day(s)', 'litespeed-cache' ); ?>
+					</div>
+					<div class="litespeed-desc">
+						<?php echo __( 'Posts older than max age (in days), will not be included in the sitemap.', 'litespeed-cache' ); ?>
+						<?php $this->_validate_ttl( $id, 1,false, true ); ?>
+					</div>
+				</div>
 			</div>
 
 		</td>


### PR DESCRIPTION
I've request a Post Max Age-logic for the Sitemap gen, more than a few mounts ago. After checking the current setup I realised how simple the plugin-structure is build up. That's great news!

Here's my take on a Post Max Age-logic.

I've already testet it on the latest version of WP with LiteSpeed server and LS Cache.

Here's one example with 90 days logics:
![image](https://user-images.githubusercontent.com/3549445/98579312-bd4cf500-22be-11eb-94df-0eb3a54288cd.png)

Here's another with 0 (= disabled):
![image](https://user-images.githubusercontent.com/3549445/98579355-d0f85b80-22be-11eb-91dc-705d9454bfa8.png)

Here's the "post"-overview for reference. Please note that the dates is listed as DD-MM-YYYY on the screenshot:
![image](https://user-images.githubusercontent.com/3549445/98579475-00a76380-22bf-11eb-99ce-69335f4d68e6.png)

