### PR TITLE
Add data-view-breakpoint-pointer to js_excludes.txt for the events calendar plugin

### DIFF
--- a/data/js_excludes.txt
+++ b/data/js_excludes.txt
@@ -17,3 +17,5 @@ dataLayer
 adsbygoogle
 
 block_tdi_ ## Theme: Newspaper by tagDiv.com
+
+data-view-breakpoint-pointer ## Plugin: The Events Calendar by Modern Tribe (https://theeventscalendar.com/)


### PR DESCRIPTION
The Events Calendar plugin has the following JS code, using a random number for data-view-breakpoint-pointer:

`var container=document.querySelectorAll('[data-view-breakpoint-pointer="e1dc3c22-dff2-465e-a450-7fea95a779b9"]');if(!container){return;}`

causing issues with the LSCache "JS combine external and inline" settings option. It leads to the disk space issues described here: [https://docs.litespeedtech.com/lscache/lscwp/ts-optimize/#disk-space-filling-fast](url)