### PR TITLE
Update js_excludes.txt

### DIFF
--- a/data/js_excludes.txt
+++ b/data/js_excludes.txt
@@ -8,6 +8,7 @@ stats.wp.com
 js.stripe.com
 paypal.com/sdk/js
 maps.google.com/maps
+spotlight-social-photo-feeds-premium
 
 # Inline JS excludes
 document.write


### PR DESCRIPTION
Put spotlight-social-photo-feeds-premium in "JS Excludes" is doing the trick and https://spotlightwp.com/ Spotlight WP Plugin is working without issues. Please add that to the excludes file :)!

Reference: https://docs.spotlightwp.com/article/756-wp-rocket-compatibility