### PR TITLE
Allow either json POST request or normal form request in notify_img

### DIFF
--- a/src/img-optm.cls.php
+++ b/src/img-optm.cls.php
@@ -626,7 +626,7 @@ class Img_Optm extends Base {
 		}
 
 		$post_data = json_decode(file_get_contents('php://input'), true);
-		if($post_data == null) {
+		if( is_null( $post_data ) ) {
 			$post_data = $_POST;
 		}
 

--- a/src/img-optm.cls.php
+++ b/src/img-optm.cls.php
@@ -625,8 +625,13 @@ class Img_Optm extends Base {
 			return Cloud::err( 'too_often' );
 		}
 
+		$post_data = json_decode(file_get_contents('php://input'), true);
+		if($post_data == null) {
+			$post_data = $_POST;
+		}
+
 		// Validate key
-		if ( empty( $_POST[ 'domain_key' ] ) || $_POST[ 'domain_key' ] !== md5( $this->conf( self::O_API_KEY ) ) ) {
+		if ( empty( $post_data[ 'domain_key' ] ) || $post_data[ 'domain_key' ] !== md5( $this->conf( self::O_API_KEY ) ) ) {
 			$this->_summary[ 'notify_ts_err' ] = time();
 			self::save_summary();
 			return Cloud::err( 'wrong_key' );
@@ -634,13 +639,13 @@ class Img_Optm extends Base {
 
 		global $wpdb;
 
-		$notified_data = $_POST[ 'data' ];
+		$notified_data = $post_data[ 'data' ];
 		if ( empty( $notified_data ) || ! is_array( $notified_data ) ) {
 			Debug2::debug( '[Img_Optm] ❌ notify exit: no notified data' );
 			return Cloud::err( 'no notified data' );
 		}
 
-		if ( empty( $_POST[ 'server' ] ) || substr( $_POST[ 'server' ], -11 ) !== '.quic.cloud' ) {
+		if ( empty( $post_data[ 'server' ] ) || substr( $post_data[ 'server' ], -11 ) !== '.quic.cloud' ) {
 			Debug2::debug( '[Img_Optm] notify exit: no/wrong server' );
 			return Cloud::err( 'no/wrong server' );
 		}
@@ -653,8 +658,8 @@ class Img_Optm extends Base {
 			self::STATUS_ERR, 			// -9 -> 'err';
 		);
 
-		if ( empty( $_POST[ 'status' ] ) || ! in_array( $_POST[ 'status' ], $_allowed_status ) ) {
-			Debug2::debug( '[Img_Optm] notify exit: no/wrong status', $_POST );
+		if ( empty( $post_data[ 'status' ] ) || ! in_array( $post_data[ 'status' ], $_allowed_status ) ) {
+			Debug2::debug( '[Img_Optm] notify exit: no/wrong status', $post_data );
 			return Cloud::err( 'no/wrong status' );
 		}
 
@@ -676,7 +681,7 @@ class Img_Optm extends Base {
 			foreach ( $list as $v ) {
 				$json = $notified_data[ $v->id ];
 
-				$server = ! empty( $json['server'] ) ? $json['server'] : $_POST['server'];
+				$server = ! empty( $json['server'] ) ? $json['server'] : $post_data['server'];
 
 				$server_info = array(
 					'server'	=> $server,


### PR DESCRIPTION
This is done to prevent hitting possible limits with max_input_vars (default 1000 in php), since we're sending 10 fields per image, we can hit this limit already after 90 images. Using json allows us to do 1000-1500 images at a time while staying within the default 2MB post request limit. This lowers the number of notify calls required, increasing efficiency both on the client-side and server-side.

The code will use php://input to get the input data from a possible json POST request, try to decode it, if it's not valid json (returns null), then we'll use $_POST instead as originally.

The image optimization service will detect based on the WP version, whether it supports json or not.