### PR TITLE
Add basic support to use CloudFlare API Tokens

### DIFF
--- a/src/cdn/cloudflare.cls.php
+++ b/src/cdn/cloudflare.cls.php
@@ -218,11 +218,19 @@ class Cloudflare extends Base {
 	private function _cloudflare_call( $url, $method = 'GET', $data = false, $show_msg = true ) {
 		Debug2::debug( "[Cloudflare] _cloudflare_call \t\t[URL] $url" );
 
-		$header = array(
-			'Content-Type: application/json',
-			'X-Auth-Email: ' . $this->conf( self::O_CDN_CLOUDFLARE_EMAIL ),
-			'X-Auth-Key: ' . $this->conf( self::O_CDN_CLOUDFLARE_KEY ),
-		);
+		if ( 40 == strlen($this->conf( self::O_CDN_CLOUDFLARE_KEY ))){
+			$header = array(
+				'Content-Type: application/json',
+				'Authorization: Bearer ' . $this->conf( self::O_CDN_CLOUDFLARE_KEY ),
+			);
+		}
+		else {
+			$header = array(
+				'Content-Type: application/json',
+				'X-Auth-Email: ' . $this->conf( self::O_CDN_CLOUDFLARE_EMAIL ),
+				'X-Auth-Key: ' . $this->conf( self::O_CDN_CLOUDFLARE_KEY ),
+			);
+		}
 
 		$ch = curl_init();
 		curl_setopt( $ch, CURLOPT_URL, $url );

--- a/src/router.cls.php
+++ b/src/router.cls.php
@@ -31,7 +31,7 @@ class Router extends Base {
 	const ACTION_IMPORT = 'import';
 	const ACTION_REPORT = 'report';
 	const ACTION_DEBUG2 = 'debug2';
-	const ACTION_CDN_CLOUDFLARE = 'CDN\\Cloudflare';
+	const ACTION_CDN_CLOUDFLARE = 'CDN\Cloudflare';
 
 	// List all handlers here
 	private static $_HANDLERS = array(
@@ -445,7 +445,12 @@ class Router extends Base {
 			return;
 		}
 
-		$action = $_REQUEST[ Router::ACTION ];
+		$action = stripslashes($_REQUEST[ Router::ACTION ]);
+		
+		if ( ! $action ) {
+		    return;
+		}
+		
 		$_is_public_action = false;
 
 		// Each action must have a valid nonce unless its from admin ip and is public action


### PR DESCRIPTION
User has to make sure their tokens have the required permissions. Recommend to generate the token using the CloudFlare API Token template "WordPress", it has all the permissions LSCWP needs.