### PR TITLE
PR: Fix for 'No valid sitemap parsed for crawler' errors

### DIFF
--- a/src/crawler-map.cls.php
+++ b/src/crawler-map.cls.php
@@ -480,8 +480,8 @@ class Crawler_Map extends Root {
 				// parse multiple sitemaps
 				foreach ( $xml_array[ 'sitemap' ] as $val ) {
 					$val = (array) $val;
-					if ( ! empty( $val[ 'loc' ] ) ) {
-						$this->_parse( $val[ 'loc' ] ); // recursive parse sitemap
+					if ( ! empty( (string) $val[ 'loc' ] ) ) {
+						$this->_parse( (string) $val[ 'loc' ] ); // recursive parse sitemap
 					}
 				}
 			}

--- a/src/crawler-map.cls.php
+++ b/src/crawler-map.cls.php
@@ -497,8 +497,8 @@ class Crawler_Map extends Root {
 			else {
 				foreach ( $xml_array[ 'url' ] as $val ) {
 					$val = (array) $val;
-					if ( ! empty( $val[ 'loc' ] ) ) {
-						$this->_urls[] = $val[ 'loc' ];
+					if ( ! empty( (string) $val[ 'loc' ] ) ) {
+						$this->_urls[] = (string) $val[ 'loc' ];
 					}
 				}
 			}


### PR DESCRIPTION
This is a fix for errors stating 'No valid sitemap parsed for crawler' errors.

This has been tested on OLS 1.7.10 and latest master of the cache plugin.

The error seems to originate because the PHP SimpleXMLElement object is not explicitly cast.  Thus to cast it to string results in the proper operation of the '! empty' checks as well as the correct population of $this->_urls used in other parts of the class.

Please let me know if there is anything else I need to do.

Thank you for a most excellent plugin.  You're a credit to open source.