### PR TITLE
Adding wp_rest nonce to the predefined nonces

### DIFF
--- a/data/esi.nonces.txt
+++ b/data/esi.nonces.txt
@@ -29,6 +29,9 @@
 
 ## Predefined list of ESI nonces:
 
+# WordPress REST nonce
+wp_rest
+
 # CM Registration Pro
 cmreg_registration_nonce private
 role_nonce private


### PR DESCRIPTION
More information in the Codex: https://developer.wordpress.org/rest-api/using-the-rest-api/authentication/

> For developers making manual Ajax requests, the nonce will need to be passed with each request. The API uses nonces with the action set to wp_rest. These can then be passed to the API via the _wpnonce data parameter (either POST data or in the query for GET requests), or via the X-WP-Nonce header. If no nonce is provided the API will set the current user to 0, turning the request into an unauthenticated request, even if you’re logged into WordPress.