### PR TITLE
Keep ESI for Elementor front pages for backward compatibility

### DIFF
--- a/thirdparty/elementor.cls.php
+++ b/thirdparty/elementor.cls.php
@@ -18,7 +18,7 @@ class Elementor
 		}
 
 		if ( ! is_admin() ) {
-		    add_action( 'init', __CLASS__ . '::disable_litespeed_esi', 4 );
+//		    add_action( 'init', __CLASS__ . '::disable_litespeed_esi', 4 );	// temporarily comment out this line for backward compatibility
 		}
 
 		if ( isset( $_GET[ 'action' ] ) && $_GET[ 'action' ] === 'elementor' ) {


### PR DESCRIPTION
Brief story: Due to some compatibility issue with Elementor and no response for a long time, we were planning to disable ESI for Elementor front pages. But considering some users has already implemented their own customized ESI on their Elementor pages, we still need to keep ESI for this for a better backward compatibility. In this case, for users having concern with the "Edit with Elementor button missing" issue, please go to Elementor edit page from wp-admin pages, or from "Edit Post" button then "edit w/ elementor"(one more click needed). Apologize for the inconvenience.