### PR TITLE
Force gravatar cache refresh in browsers and on Cloudflare

### DIFF
--- a/src/avatar.cls.php
+++ b/src/avatar.cls.php
@@ -105,7 +105,7 @@ class Avatar extends Base {
 		$realpath = $this->_realpath( $url );
 		if ( file_exists( $realpath ) && time() - filemtime( $realpath ) <= $this->_conf_cache_ttl ) {
 			Debug2::debug2( '[Avatar] cache file exists [url] ' . $url );
-			return $this->_rewrite( $url );
+			return $this->_rewrite( $url, filemtime( $realpath ) );
 		}
 
 		if ( ! strpos( $url, 'gravatar.com' ) ) {
@@ -149,8 +149,8 @@ class Avatar extends Base {
 	 *
 	 * @since  3.0
 	 */
-	private function _rewrite( $url ) {
-		return LITESPEED_STATIC_URL . '/avatar/' . $this->_filepath( $url );
+	private function _rewrite( $url, $time = null ) {
+		return LITESPEED_STATIC_URL . '/avatar/' . $this->_filepath( $url ) . ( $time ? '?ver=' . $time : '' );
 	}
 
 	/**


### PR DESCRIPTION
Resolves #322 

This PR adds a query string `?ver` with the date the gravatar was saved. This way, when a user changes their avatar, it will be immediately visible after clearing the gravatar cache. No more need to manually purge the cache on Cloudflare and in the browser.