### PR TITLE
Add ESI shortcode support for silence parameter

### DIFF
--- a/src/esi.cls.php
+++ b/src/esi.cls.php
@@ -210,7 +210,7 @@ class ESI extends Root {
 		}
 
 		$silence = false;
-		if ( ! empty( $atts[ '_ls_silence' ] ) && ( $atts[ '_ls_silence' ] ) ) {
+		if ( ! empty( $atts[ '_ls_silence' ] ) ) {
 			$silence = true;
 		}
 

--- a/src/esi.cls.php
+++ b/src/esi.cls.php
@@ -100,6 +100,7 @@ class ESI extends Root {
 		 *
 		 * 	1. `cache` attribute is optional, default to 'public,no-vary'.
 		 * 	2. `ttl` attribute is optional, default is your public TTL setting.
+		 *  3. `_ls_silence` attribute is optional, default is false.
 		 *
 		 * @since  2.8
 		 * @since  2.8.1 Check is_admin for Elementor compatibility #726013
@@ -208,10 +209,15 @@ class ESI extends Root {
 			unset( $atts[ 'cache' ] );
 		}
 
+		$silence = false;
+		if ( ! empty( $atts[ '_ls_silence' ] ) && ( $atts[ '_ls_silence' ] ) ) {
+			$silence = true;
+		}
+
 		do_action( 'litespeed_esi_shortcode-' . $atts[ 0 ] );
 
 		// Show ESI link
-		return $this->sub_esi_block( 'esi', 'esi-shortcode', $atts, $cache );
+		return $this->sub_esi_block( 'esi', 'esi-shortcode', $atts, $cache, $silence );
 	}
 
 	/**
@@ -423,7 +429,7 @@ class ESI extends Root {
 		}
 
 		if ( $silence ) {
-			// Don't add comment to esi block ( orignal for nonce used in tag property data-nonce='esi_block' )
+			// Don't add comment to esi block ( original for nonce used in tag property data-nonce='esi_block' )
 			$params[ '_ls_silence' ] = true;
 		}
 


### PR DESCRIPTION
This change allows you to add the `_ls_silence=true` parameter to the `esi` shortcode modifier to prevent the output of ESI comments in the shortcode output. This is especially helpful when using shortcodes in javascript.

As a case in point, we are using ESI with a shortcode that generates a custom URL for a media item played through JWPlayer. Since the shortcode is intended to return a plain URL, the normal ESI comments then cause the URL to become invalid.

```php
<script type="text/javascript">
  jwplayer("contentvideo_block").setup({
    id: "jwplayervideohtml",
    file: "[esi hls_url filename='[types field='video-filename'][/types]'",
```

While the output contains a valid HTML comment, this comment breaks the javascript property assignment:

![image](https://user-images.githubusercontent.com/7254992/161641334-e92eebb7-8c0b-4eff-8607-42abec787d8e.png)

With this proposed change, I can simply adjust my shortcode to add the new parameter:

![image](https://user-images.githubusercontent.com/7254992/161641590-075aae9e-7173-4ef3-936f-10fce920e9eb.png)

The output then does not include the comments, and everything works just as I would expect.

I believe this would benefit other users as well in cases where you need to skip the comment output in specific shortcodes without having to disable them at the global level.

Thanks for your consideration!!  😄 