### PR TITLE
Run ACTION_PURGE_EMPTYCACHE even if cache is disabled in network admin

### DIFF
--- a/src/router.cls.php
+++ b/src/router.cls.php
@@ -537,7 +537,7 @@ class Router extends Base {
 				return;
 
 			case Core::ACTION_PURGE_EMPTYCACHE:// todo: moved to purge.cls type action
-				if ( defined( 'LITESPEED_ON' ) && ( $_can_network_option || ( ! $_is_multisite && $_can_option ) ) ) {
+				if ( ( defined( 'LITESPEED_ON' ) || $_is_network_admin ) && ( $_can_network_option || ( ! $_is_multisite && $_can_option ) ) ) {
 					self::$_action = $action;
 				}
 				return;


### PR DESCRIPTION
Allow the entire cache to be purged through network admin even if
Network Enable Cache is set to Off as it can still be enabled per site.