### PR TITLE
Remove load recommendation for crawler

### DIFF
--- a/tpl/crawler/settings-general.tpl.php
+++ b/tpl/crawler/settings-general.tpl.php
@@ -145,9 +145,6 @@ $this->form_action();
 						<?php echo __('NOTE', 'litespeed-cache'); ?>:
 						<?php echo __( 'Server allowed max value', 'litespeed-cache'); ?>: <code><?php echo $_SERVER[ Base::ENV_CRAWLER_LOAD_LIMIT ]; ?></code>
 					</font>
-				<?php else : ?>
-					<?php $this->recommended($id); ?>
-
 				<?php endif; ?>
 
 				<br />


### PR DESCRIPTION
It's not useful for LSCWP to recommend any load:

- a limit of 1 might not make sense in multi-core systems, the load is often higher
- a determined limit based on the number of cores isn't useful either
  because you might not want to push your systems to e.g. 3/4s of your cores
- the site owner should talk to their host, and know the server load anyway to determine a correct value
  (or let the host enforce it)

As a result, giving a recommendation isn't beneficial for anyone, neither the customer or the hosting provider