### PR TITLE
Add an incompatible plugin notification

### DIFF
--- a/src/activation.cls.php
+++ b/src/activation.cls.php
@@ -69,6 +69,11 @@ class Activation extends Base {
 		if ( defined( 'LSCWP_REF' ) && LSCWP_REF == 'whm' ) {
 			GUI::update_option( GUI::WHM_MSG, GUI::WHM_MSG_VAL );
 		}
+
+		Thirdparty\LiteSpeed_Check::activated_plugin(
+			basename( LSCWP_DIR ) . '/litespeed-cache.php',
+			null
+		);
 	}
 
 	/**
@@ -253,6 +258,11 @@ class Activation extends Base {
 
 		// delete in case it's not deleted prior to deactivation.
 		GUI::dismiss_whm();
+
+		Thirdparty\LiteSpeed_Check::deactivated_plugin(
+			basename( LSCWP_DIR ) . '/litespeed-cache.php',
+			null
+		);
 	}
 
 	/**

--- a/src/activation.cls.php
+++ b/src/activation.cls.php
@@ -258,11 +258,6 @@ class Activation extends Base {
 
 		// delete in case it's not deleted prior to deactivation.
 		GUI::dismiss_whm();
-
-		Thirdparty\LiteSpeed_Check::deactivated_plugin(
-			basename( LSCWP_DIR ) . '/litespeed-cache.php',
-			null
-		);
 	}
 
 	/**

--- a/src/activation.cls.php
+++ b/src/activation.cls.php
@@ -69,11 +69,6 @@ class Activation extends Base {
 		if ( defined( 'LSCWP_REF' ) && LSCWP_REF == 'whm' ) {
 			GUI::update_option( GUI::WHM_MSG, GUI::WHM_MSG_VAL );
 		}
-
-		Thirdparty\LiteSpeed_Check::activated_plugin(
-			basename( LSCWP_DIR ) . '/litespeed-cache.php',
-			null
-		);
 	}
 
 	/**

--- a/thirdparty/entry.inc.php
+++ b/thirdparty/entry.inc.php
@@ -23,6 +23,7 @@ $third_cls = array(
 	'Caldera_Forms',
 	'Divi_Theme_Builder',
 	'Facetwp',
+	'LiteSpeed_Check',
 	'Theme_My_Login',
 	'User_Switching',
 	'WCML',

--- a/thirdparty/litespeed-check.cls.php
+++ b/thirdparty/litespeed-check.cls.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Check if certain plugin that could conflict with LiteSpeed Cache is activated.
+ * @since		4.2
+ */
+
+namespace LiteSpeed\Thirdparty;
+
+defined( 'WPINC' ) || exit;
+
+class LiteSpeed_Check {
+
+	public static function detect() {
+
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		$user_id = get_current_user_id();
+
+		if ( isset( $_GET[ 'lscwp_temp_warning_plugin' ] ) ) {
+			add_user_meta( $user_id, 'litespeed.conf_temp_warning_dismiss_plugin', 'true', true );
+		}
+
+		if ( isset( $_GET[ 'lscwp_temp_warning_ssl' ] ) ) {
+			add_user_meta( $user_id, 'litespeed.conf_temp_warning_dismiss_ssl', 'true', true );
+		}
+
+		if ( ! get_user_meta( $user_id, 'litespeed.conf_temp_warning_dismiss_plugin' ) ) {
+			session_start();
+
+			$plugin_list =
+				array_map(
+					function( $plugin ) { return WP_PLUGIN_DIR . '/' . $plugin; },
+					[
+						'autoptimize/autoptimize.php',
+						'breeze/breeze.php',
+						'cache-enabler/cache-enabler.php',
+						'cachify/cachify.php',
+						'cloudflare/cloudflare.php',
+						'comet-cache/comet-cache.php',
+						'docket-cache/docket-cache.php',
+						'fast-velocity-minify/fvm.php',
+						'hummingbird-performance/wp-hummingbird.php',
+						'nginx-cache/nginx-cache.php',
+						'nitropack/main.php',
+						'pantheon-advanced-page-cache/pantheon-advanced-page-cache.php',
+						'powered-cache/powered-cache.php',
+						'sg-cachepress/sg-cachepress.php',
+						'simple-cache/simple-cache.php',
+						'redis-cache/redis-cache.php',
+						'w3-total-cache/w3-total-cache.php',
+						'wp-cloudflare-page-cache/wp-cloudflare-page-cache.php',
+						'wp-fastest-cache/wpFastestCache.php',
+						'wp-meteor/wp-meteor.php',
+						'wp-optimize/wp-optimize.php',
+						'wp-performance-score-booster/wp-performance-score-booster.php',
+						'wp-rocket/wp-rocket.php',
+						'wp-super-cache/wp-cache.php',
+					]
+				);
+
+			$_SESSION[ 'lscwp_temp_warning' ] =
+				array_map(
+					function( $plugin ) {
+						return get_plugin_data( $plugin, false, true )[ 'Name' ];
+					},
+					array_intersect( $plugin_list, wp_get_active_and_valid_plugins() )
+				);
+
+			if ( ! empty( $_SESSION[ 'lscwp_temp_warning' ] ) ) {
+				add_action( 'admin_notices', function() {
+					?>
+					<div class="notice notice-error is-dismissible">
+						<p><?php
+							esc_html_e(
+								'Please consider disabling the following detected plugins, as they may conflict with LiteSpeed Cache:',
+								'litespeed-cache'
+							);
+						?>
+							<br>
+							<p style="color: red;"><?php
+								echo implode( ', ', $_SESSION[ 'lscwp_temp_warning' ] );
+							?></p><a href="?lscwp_temp_warning_plugin"><?php
+								esc_html_e( 'Dismiss', 'litespeed-cache' );
+						?></a></p>
+					</div>
+					<?php
+				} );
+			}
+		}
+
+		if ( ! get_user_meta( $user_id, 'litespeed.conf_temp_warning_dismiss_ssl' ) ) {
+			if ( strpos( WP_CONTENT_URL , get_site_url() ) === false ) {
+				# have to use WP_CONTENT_URL to get true scheme 
+				add_action( 'admin_notices', function() {
+					?>
+					<div class="notice notice-error is-dismissible">
+						<p><?php
+							printf(
+								esc_html__( 'Detected WordPress URL: %s', 'litespeed-cache' ),
+								'<p style="color: red;">' . site_url() . '</p>'
+							);
+							?>
+							<br>
+							<?php
+							printf(
+								esc_html__( 'Detected Wordpress Content URL: %s', 'litespeed-cache' ),
+								'<p style="color: red;">' . WP_CONTENT_URL . '</p>'
+							);
+							?>
+							<br>
+							<?php
+							printf(
+								esc_html__(
+									'It appears that you are using %1$s and %2$s inconsistently. Please visit %3$s and update the WordPress Address or Site Address to avoid a mixed content error.',
+									'litespeed-cache'
+								),
+								'<strong>' . esc_html__( 'HTTP', 'litespeed-cache' ) . '</strong>',
+								'<strong>' . esc_html__( 'HTTPS', 'litespeed-cache' ) . '</strong>',
+								'<a href="' . get_admin_url() . 'options-general.php">'
+								. esc_html__( 'Settings -> General', 'litespeed-cache' )
+								. '</a>'
+							);
+							?>
+							<br><br><a href="?lscwp_temp_warning_ssl"><?php
+								esc_html_e( 'Dismiss', 'litespeed-cache' );
+						?></a></p>
+					</div>
+					<?php
+				} );
+			}
+		}
+	}
+}

--- a/thirdparty/litespeed-check.cls.php
+++ b/thirdparty/litespeed-check.cls.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Check if certain plugin that could conflict with LiteSpeed Cache is activated.
- * @since		4.2
+ * Check if any plugins that could conflict with LiteSpeed Cache are active.
+ * @since		4.6
  */
 
 namespace LiteSpeed\Thirdparty;
@@ -10,126 +10,103 @@ defined( 'WPINC' ) || exit;
 
 class LiteSpeed_Check {
 
-	public static function detect() {
+	public static $_incompatible_plugins =
+		array(
+			'autoptimize/autoptimize.php',
+			'breeze/breeze.php',
+			'cache-enabler/cache-enabler.php',
+			'cachify/cachify.php',
+			'cloudflare/cloudflare.php',
+			'comet-cache/comet-cache.php',
+			'docket-cache/docket-cache.php',
+			'fast-velocity-minify/fvm.php',
+			'hummingbird-performance/wp-hummingbird.php',
+			'nginx-cache/nginx-cache.php',
+			'nitropack/main.php',
+			'pantheon-advanced-page-cache/pantheon-advanced-page-cache.php',
+			'powered-cache/powered-cache.php',
+			'sg-cachepress/sg-cachepress.php',
+			'simple-cache/simple-cache.php',
+			'redis-cache/redis-cache.php',
+			'w3-total-cache/w3-total-cache.php',
+			'wp-cloudflare-page-cache/wp-cloudflare-page-cache.php',
+			'wp-fastest-cache/wpFastestCache.php',
+			'wp-meteor/wp-meteor.php',
+			'wp-optimize/wp-optimize.php',
+			'wp-performance-score-booster/wp-performance-score-booster.php',
+			'wp-rocket/wp-rocket.php',
+			'wp-super-cache/wp-cache.php',
+		);
 
+	private static $_meta_key = 'litespeed.conf_temp_warning_dismiss_plugin';
+
+	public static function on_plugins_changed( $_plugin, $_network_wide ) {
+		delete_user_meta( get_current_user_id(), self::$_meta_key );
+	}
+
+	public static function detect() {
 		if ( ! is_admin() ) {
 			return;
 		}
 
-		$user_id = get_current_user_id();
+		add_action( 'activated_plugin', __CLASS__ . '::on_plugins_changed', 10, 2 );
+		add_action( 'deactivated_plugin', __CLASS__ . '::on_plugins_changed', 10, 2 );
 
-		if ( isset( $_GET[ 'lscwp_temp_warning_plugin' ] ) ) {
-			add_user_meta( $user_id, 'litespeed.conf_temp_warning_dismiss_plugin', 'true', true );
+		if ( isset( $_GET[ 'lscwp_incompatible_plugins' ] )
+		&& 'dismiss' === $_GET[ 'lscwp_incompatible_plugins' ]
+		&& check_admin_referer( 'lscwp_dismiss_incompatible_plugins' ) ) {
+			add_user_meta( get_current_user_id(), self::$_meta_key, 'true', true );
+			return;
 		}
 
-		if ( isset( $_GET[ 'lscwp_temp_warning_ssl' ] ) ) {
-			add_user_meta( $user_id, 'litespeed.conf_temp_warning_dismiss_ssl', 'true', true );
+		if ( ! get_user_meta( get_current_user_id(), self::$_meta_key ) ) {
+			add_action( 'admin_notices', __CLASS__ . '::incompatible_plugin_notice' );
+		}
+	}
+
+	public static function incompatible_plugin_notice() {
+		$incompatible_plugins =
+			array_map(
+				function( $plugin ) { return WP_PLUGIN_DIR . '/' . $plugin; },
+				self::$_incompatible_plugins
+			);
+
+		$active_incompatible_plugins =
+			array_map(
+				function( $plugin ) {
+					$plugin = get_plugin_data( $plugin, false, true );
+					return $plugin[ 'Name' ];
+				},
+				array_intersect( $incompatible_plugins, wp_get_active_and_valid_plugins() )
+			);
+
+		if ( empty( $active_incompatible_plugins ) ) {
+			return;
 		}
 
-		if ( ! get_user_meta( $user_id, 'litespeed.conf_temp_warning_dismiss_plugin' ) ) {
-			session_start();
-
-			$plugin_list =
-				array_map(
-					function( $plugin ) { return WP_PLUGIN_DIR . '/' . $plugin; },
-					[
-						'autoptimize/autoptimize.php',
-						'breeze/breeze.php',
-						'cache-enabler/cache-enabler.php',
-						'cachify/cachify.php',
-						'cloudflare/cloudflare.php',
-						'comet-cache/comet-cache.php',
-						'docket-cache/docket-cache.php',
-						'fast-velocity-minify/fvm.php',
-						'hummingbird-performance/wp-hummingbird.php',
-						'nginx-cache/nginx-cache.php',
-						'nitropack/main.php',
-						'pantheon-advanced-page-cache/pantheon-advanced-page-cache.php',
-						'powered-cache/powered-cache.php',
-						'sg-cachepress/sg-cachepress.php',
-						'simple-cache/simple-cache.php',
-						'redis-cache/redis-cache.php',
-						'w3-total-cache/w3-total-cache.php',
-						'wp-cloudflare-page-cache/wp-cloudflare-page-cache.php',
-						'wp-fastest-cache/wpFastestCache.php',
-						'wp-meteor/wp-meteor.php',
-						'wp-optimize/wp-optimize.php',
-						'wp-performance-score-booster/wp-performance-score-booster.php',
-						'wp-rocket/wp-rocket.php',
-						'wp-super-cache/wp-cache.php',
-					]
-				);
-
-			$_SESSION[ 'lscwp_temp_warning' ] =
-				array_map(
-					function( $plugin ) {
-						return get_plugin_data( $plugin, false, true )[ 'Name' ];
-					},
-					array_intersect( $plugin_list, wp_get_active_and_valid_plugins() )
-				);
-
-			if ( ! empty( $_SESSION[ 'lscwp_temp_warning' ] ) ) {
-				add_action( 'admin_notices', function() {
-					?>
-					<div class="notice notice-error is-dismissible">
-						<p><?php
-							esc_html_e(
-								'Please consider disabling the following detected plugins, as they may conflict with LiteSpeed Cache:',
-								'litespeed-cache'
-							);
-						?>
-							<br>
-							<p style="color: red;"><?php
-								echo implode( ', ', $_SESSION[ 'lscwp_temp_warning' ] );
-							?></p><a href="?lscwp_temp_warning_plugin"><?php
-								esc_html_e( 'Dismiss', 'litespeed-cache' );
-						?></a></p>
-					</div>
-					<?php
-				} );
-			}
-		}
-
-		if ( ! get_user_meta( $user_id, 'litespeed.conf_temp_warning_dismiss_ssl' ) ) {
-			if ( strpos( WP_CONTENT_URL , get_site_url() ) === false ) {
-				# have to use WP_CONTENT_URL to get true scheme 
-				add_action( 'admin_notices', function() {
-					?>
-					<div class="notice notice-error is-dismissible">
-						<p><?php
-							printf(
-								esc_html__( 'Detected WordPress URL: %s', 'litespeed-cache' ),
-								'<p style="color: red;">' . site_url() . '</p>'
-							);
-							?>
-							<br>
-							<?php
-							printf(
-								esc_html__( 'Detected Wordpress Content URL: %s', 'litespeed-cache' ),
-								'<p style="color: red;">' . WP_CONTENT_URL . '</p>'
-							);
-							?>
-							<br>
-							<?php
-							printf(
-								esc_html__(
-									'It appears that you are using %1$s and %2$s inconsistently. Please visit %3$s and update the WordPress Address or Site Address to avoid a mixed content error.',
-									'litespeed-cache'
-								),
-								'<strong>' . esc_html__( 'HTTP', 'litespeed-cache' ) . '</strong>',
-								'<strong>' . esc_html__( 'HTTPS', 'litespeed-cache' ) . '</strong>',
-								'<a href="' . get_admin_url() . 'options-general.php">'
-								. esc_html__( 'Settings -> General', 'litespeed-cache' )
-								. '</a>'
-							);
-							?>
-							<br><br><a href="?lscwp_temp_warning_ssl"><?php
-								esc_html_e( 'Dismiss', 'litespeed-cache' );
-						?></a></p>
-					</div>
-					<?php
-				} );
-			}
-		}
+		?>
+		<div class="notice notice-error litespeed-irremovable">
+			<p>
+				<?php
+					esc_html_e(
+						'Please consider disabling the following detected plugins, as they may conflict with LiteSpeed Cache:',
+						'litespeed-cache'
+					);
+				?>
+				<br>
+				<p style="color: red; font-weight: 700;"><?php
+					echo implode( ', ', $active_incompatible_plugins );
+				?></p>
+				<a href="<?php
+					echo wp_nonce_url(
+						add_query_arg( 'lscwp_incompatible_plugins', 'dismiss' ),
+						'lscwp_dismiss_incompatible_plugins'
+					);
+				?>" class="button litespeed-btn-primary litespeed-btn-mini"><?php
+					esc_html_e( 'Dismiss', 'litespeed-cache' );
+				?></a>
+			</p>
+		</div>
+		<?php
 	}
 }


### PR DESCRIPTION
Incompatible plugin notification:
- Can be dismissed
- Is refreshed when any plugin is (de)activated
- Is refreshed when `litespeed-cache` itself is activated