### PR TITLE
Don't correct hash-tag URLs when minifying css

### DIFF
--- a/lib/css-min/urirewriter.cls.php
+++ b/lib/css-min/urirewriter.cls.php
@@ -291,8 +291,8 @@ class UriRewriter
             return $m[0];
         }
 
-        // if not root/scheme relative and not starts with scheme
-        if (!preg_match('~^(/|[a-z]+\:)~', $uri)) {
+        // if not anchor id, not root/scheme relative, and not starts with scheme
+        if (!preg_match('~^(#|/|[a-z]+\:)~', $uri)) {
             // URI is file-relative: rewrite depending on options
             if (self::$_prependPath === null) {
                 $uri = self::rewriteRelative($uri, self::$_currentDir, self::$_docRoot, self::$_symlinks);


### PR DESCRIPTION
As discussed in: https://wordpress.org/support/topic/css-minify-combine-breaks-clip-path/

CSS rules like this:

```css
.some { property: url(#my-object); }
```

were rewritten and minified like this:

```css
.some{property:url(/wp-content/themes/twentytwentyone/#my-object)}
```

With this PR they're not rewritten anymore, and end up like this after minification:

```css
.some{property:url(#my-object)}
```

Closes #463.