### PR TITLE
Update ucss_whitelist.txt

### DIFF
--- a/data/ucss_whitelist.txt
+++ b/data/ucss_whitelist.txt
@@ -8,3 +8,7 @@
 
 ############# DIVI ################
 .et_pb_number_counter.active
+
+############# AVADA ################
+.fusion-mobile*
+.fusion-open-submenu*


### PR DESCRIPTION
Fixes Avada mobile menu. Avada creates mobile menu on-the-fly via Javascript. That's why class names are not showing up in source code.