### PR TITLE
Fix: Let VPI work on the posts page

### DIFF
--- a/src/metabox.cls.php
+++ b/src/metabox.cls.php
@@ -97,9 +97,11 @@ class Metabox extends Root {
 	public function setting( $conf, $post_id = false ) {
 		// Check if has metabox non-cacheable setting or not
 		if ( ! $post_id ) {
+			$home_id = get_option( 'page_for_posts' );
 			if ( is_singular() ) {
 				$post_id = get_the_ID();
-
+			} elseif ( $home_id > 0 && is_home() ) {
+				$post_id = $home_id;
 			}
 		}
 

--- a/src/vpi.cls.php
+++ b/src/vpi.cls.php
@@ -43,12 +43,14 @@ class VPI extends Base {
 			return;
 		}
 
-		if ( ! is_singular() ) {
+		$home_id = get_option( 'page_for_posts' );
+
+		if ( ! is_singular() && ! ( $home_id > 0 && is_home() ) ) {
 			self::debug( 'not single post ID' );
 			return;
 		}
 
-		$post_id = get_the_ID();
+		$post_id = is_home() ? $home_id : get_the_ID();
 
 		$queue_k = ( $is_mobile ? 'mobile' : '' ) . ' ' . $request_url;
 		if ( ! empty( $this->_queue[ $queue_k ] ) ) {


### PR DESCRIPTION
This fix allows VPI functionality to work on a page set as the WordPress "Posts page," for which `is_singular()` returns `false`.