### PR TITLE
CLI: Added 'import_remote' in litespeed-option to be able to import o…

### DIFF
--- a/cli/option.cls.php
+++ b/cli/option.cls.php
@@ -331,6 +331,46 @@ class Option extends Base {
 	}
 
 	/**
+	 * Import plugin options from a remote file.
+	 *
+	 * The file must be formatted as such:
+	 * option_key=option_value
+	 * One per line.
+	 * A Semicolon at the beginning of the line indicates a comment and will be skipped.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <url>
+	 * : The URL to import options from.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Import options from https://domain.com/options.txt
+	 *     $ wp litespeed-option import_remote https://domain.com/options.txt
+	 *
+	 */
+
+	public function import_remote( $args, $assoc_args ) {
+		$file = $args[0];
+	
+		$tmp_file = download_url( $file );
+
+		if ( is_wp_error( $tmp_file ) ) {
+			WP_CLI::error( 'Failed to download file.' );
+			return;
+		}
+
+		$res = $this->cls( 'Import' )->import( $tmp_file );
+
+		if ( ! $res ) {
+			WP_CLI::error( 'Failed to parse serialized data from file.' );
+		}
+
+		WP_CLI::success( 'Options imported. [File] ' . $file );
+	}
+
+
+	/**
 	 * Reset all options to default.
 	 *
 	 * ## EXAMPLES


### PR DESCRIPTION
I have added the "import_remote" option inside the "wp litespeed-option" command to be able to import options with URLs remotely. 

This way, if you have many WordPress and want to use the CLI, you can upload a single options.data file to a host, and make the request to that URL. In case you want to add, remove or modify one of the options, you only have to do it in that file and not in multiple servers/installations.

The mode of use is as follows:
`wp litespeed-option import_remote https://domain.com/options.data`

The import function used is the same as in "wp litespeed-option import options.txt".