### PR TITLE
Fix object cache lib incr, desr functions (thanks bdrbros)

### DIFF
--- a/src/object.lib.php
+++ b/src/object.lib.php
@@ -912,7 +912,7 @@ class WP_Object_Cache {
 	 * @return int|false The item's new value on success, false on failure.
 	 */
 	public function incr( $key, $offset = 1, $group = 'default' ) {
-		return incr_desr( $key, $offset, $group, true );
+		return $this->incr_desr( $key, $offset, $group, true );
 	}
 
 	/**
@@ -927,7 +927,7 @@ class WP_Object_Cache {
 	 * @return int|false The item's new value on success, false on failure.
 	 */
 	public function decr( $key, $offset = 1, $group = 'default' ) {
-		return incr_desr( $key, $offset, $group, false );
+		return $this->incr_desr( $key, $offset, $group, false );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/internal-server-error-uncaught-error-call-to-undefined-function-incr_desr/