### PR TITLE
Fix implicit conversion in Str::rrand

### DIFF
--- a/src/str.cls.php
+++ b/src/str.cls.php
@@ -20,7 +20,7 @@ class Str {
 	 * @return string
 	 */
 	public static function rrand( $len, $type = 7 ) {
-		mt_srand( ( double ) microtime() * 1000000 );
+		mt_srand( (int) ( ( double ) microtime() * 1000000 ) );
 
 		switch( $type ) {
 			case 0 :


### PR DESCRIPTION
Fixes e.g.
```
PHP Deprecated:  Implicit conversion from float 516692.99999999994 to int loses precision in .../src/str.cls.php on line 23
```