### PR TITLE
Fix dynamic property deprecation warnings

### DIFF
--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -32,6 +32,7 @@ class Object_Cache extends Root {
 	private $_cfg_method;
 	private $_cfg_host;
 	private $_cfg_port;
+	private $_cfg_life;
 	private $_cfg_persistent;
 	private $_cfg_admin;
 	private $_cfg_transients;

--- a/src/placeholder.cls.php
+++ b/src/placeholder.cls.php
@@ -23,6 +23,7 @@ class Placeholder extends Base {
 	private $_conf_lqip_min_h;
 	private $_conf_placeholder_resp_color;
 	private $_conf_placeholder_resp_async;
+	private $_conf_ph_default;
 	private $_placeholder_resp_dict = array();
 	private $_ph_queue = array();
 


### PR DESCRIPTION
See: https://wordpress.org/support/topic/php-8-2-deprecated-warning/