### PR TITLE
Prevent undefined array key warning when widgets are disabled

### DIFF
--- a/src/purge.cls.php
+++ b/src/purge.cls.php
@@ -1144,8 +1144,11 @@ class Purge extends Base {
 
 		global $wp_widget_factory;
 		// recent_posts
-		if ( ! is_null( $wp_widget_factory->widgets['WP_Widget_Recent_Posts'] ) ) {
-			$purge_tags[] = Tag::TYPE_WIDGET . $wp_widget_factory->widgets['WP_Widget_Recent_Posts']->id;
+		$recent_posts = isset( $wp_widget_factory->widgets['WP_Widget_Recent_Posts'] )
+			? $wp_widget_factory->widgets['WP_Widget_Recent_Posts']
+			: null;
+		if ( ! is_null( $recent_posts ) ) {
+			$purge_tags[] = Tag::TYPE_WIDGET . $recent_posts->id;
 		}
 
 		// get adjacent posts id as related post tag


### PR DESCRIPTION
Fixes a warning when Widget functionality is completely removed.
```
PHP Warning: Undefined array key "WP_Widget_Recent_Posts" in .../litespeed-cache/src/purge.cls.php on line 1149
```