### PR TITLE
Enable webp support for Lighthouse User Agent

### DIFF
--- a/src/media.cls.php
+++ b/src/media.cls.php
@@ -387,8 +387,9 @@ class Media extends Root {
 		}
 
 		if ( ! empty( $_SERVER[ 'HTTP_USER_AGENT' ] ) ) {
-			foreach ( array( 'Chrome-Lighthouse', 'Page Speed' ) as $needle ) {
-				if ( stripos( $_SERVER[ 'HTTP_USER_AGENT' ], $needle ) !== false ) {
+			$user_agents = array( 'chrome-lighthouse', 'googlebot', 'page speed' );
+			foreach ( $user_agents as $user_agent ) {
+				if ( stripos( $_SERVER[ 'HTTP_USER_AGENT' ], $user_agent ) !== false ) {
 					return true;
 				}
 			}

--- a/src/media.cls.php
+++ b/src/media.cls.php
@@ -387,8 +387,10 @@ class Media extends Root {
 		}
 
 		if ( ! empty( $_SERVER[ 'HTTP_USER_AGENT' ] ) ) {
-			if ( strpos( $_SERVER[ 'HTTP_USER_AGENT' ], 'Page Speed' ) !== false ) {
-				return true;
+			foreach ( array( 'Chrome-Lighthouse', 'Page Speed' ) as $needle ) {
+				if ( stripos( $_SERVER[ 'HTTP_USER_AGENT' ], $needle ) !== false ) {
+					return true;
+				}
 			}
 
 			if ( preg_match( "/iPhone OS (\d+)_/i", $_SERVER[ 'HTTP_USER_AGENT' ], $matches ) ) {


### PR DESCRIPTION
Addresses the case where `Chrome-Lighthouse` doesn't report `image/webp` in the accept header, but instead uses:
```
Accept: */*
```