### PR TITLE
Fix warnings for WP < v5.3

### DIFF
--- a/src/activation.cls.php
+++ b/src/activation.cls.php
@@ -38,6 +38,14 @@ class Activation extends Base {
 	 * @access public
 	 */
 	public static function register_activation() {
+		global $wp_version;
+		$advanced_cache = LSCWP_CONTENT_DIR . '/advanced-cache.php';
+		if ( version_compare( $wp_version, '5.3', '<' ) && ! file_exists( $advanced_cache ) ) {
+			$file_pointer = fopen( $advanced_cache, 'w' );
+			fwrite( $file_pointer, "<?php\n\n// A compatibility placeholder for WordPress < v5.3\n" );
+			fclose( $file_pointer );
+		}
+
 		$count = 0;
 		! defined( 'LSCWP_LOG_TAG' ) && define( 'LSCWP_LOG_TAG', 'Activate_' . get_current_blog_id() );
 


### PR DESCRIPTION
Fixes warnings like:

```
[STDERR] PHP Warning:  include(.../wp-content/advanced-cache.php): failed to open stream: No such file or directory in .../wp-settings.php on line 84
```

A check for this file happens before plugins are loaded, and can omit this warning for any cache plugin.

Beginning with WordPress v5.3, this fix is not needed.