### PR TITLE
Fix a warning for null get_post_type_object

### DIFF
--- a/src/metabox.cls.php
+++ b/src/metabox.cls.php
@@ -52,7 +52,7 @@ class Metabox extends Root {
 			return;
 		}
 		$post_type_obj = get_post_type_object( $post_type );
-		if ( !$post_type_obj->public ) {
+		if ( ! empty( $post_type_obj ) && ! $post_type_obj->public ) {
 			self::debug('post type public=false, bypass add_meta_boxes');
 			return;
 		}


### PR DESCRIPTION
Addresses: https://wordpress.org/support/topic/php-warning-attempt-to-read-property-public-on-null/