### PR TITLE
Add bypass filter litespeed_html_min

### DIFF
--- a/src/optimizer.cls.php
+++ b/src/optimizer.cls.php
@@ -30,6 +30,11 @@ class Optimizer extends Root {
 	 * @access public
 	 */
 	public function html_min( $content, $force_inline_minify = false ) {
+		if ( ! apply_filters( 'litespeed_html_min', true ) ) {
+			Debug2::debug2( '[Optmer] html_min bypassed via litespeed_html_min filter' );
+			return $content;
+		}
+
 		$options = array();
 
 		if ( $force_inline_minify ) {


### PR DESCRIPTION
Sometimes HTML minification produces bad results (e.g. blank page).

This filter allows bypassing HTML minification, particularly useful for keeping Guest Optimization enabled when HTML minification is undesirable.