### PR TITLE
Notify instead of throwing Redis exception

### DIFF
--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -469,7 +469,13 @@ class Object_Cache extends Root {
 			try {
 				$res = $this->_conn->setEx( $key, $ttl, $data );
 			} catch ( \RedisException $ex ) {
-				throw new \Exception( $ex->getMessage(), $ex->getCode(), $ex );
+				$msg = sprintf(
+					__( 'Redis encountered a fatal error: %s (code: %d)', 'litespeed-cache' ),
+					$ex->getMessage(),
+					$ex->getCode()
+				);
+				Debug2::debug( '[Object] ' . $msg );
+				Admin_Display::error( $msg );
 			}
 		}
 		else {


### PR DESCRIPTION
Avoid crashing PHP so the user can more easily address the issue.