### PR TITLE
Fix an issue where the LiteSpeed icon can escape its container

### DIFF
--- a/assets/css/litespeed.css
+++ b/assets/css/litespeed.css
@@ -141,6 +141,7 @@ input[type="checkbox"].litespeed-tiny-toggle:checked:after {
 
 .litespeed_icon {
 	padding-left: 30px !important;
+	position: relative;
 }
 
 .rtl .litespeed_icon {


### PR DESCRIPTION
The issue is currently observable via:

```php
Admin_Display::error( 'message', false, true );
```