### PR TITLE
Fix generate UCSS for error page

### DIFF
--- a/src/css.cls.php
+++ b/src/css.cls.php
@@ -402,6 +402,9 @@ class CSS extends Base {
 		$html = $this->cls( 'Crawler' )->self_curl( add_query_arg( 'LSCWP_CTRL', 'before_optm', $request_url ), $user_agent, $uid );
 		Debug2::debug2( '[CSS] self_curl result....', $html );
 
+		if ( ! $html ) {
+			return false;
+		}
 
 		$html = $this->cls( 'Optimizer' )->html_min( $html, true );
 		// Drop <noscript>xxx</noscript>


### PR DESCRIPTION
Fix sending empty html to cloud causing wrong UCSS to be generated.

Because `self_curl()` will return `false` if it is not 200, and passing it directly to `html_min()` without checking will convert the result to empty html.

https://github.com/litespeedtech/lscache_wp/blob/d1a0aef92424d1c32886f4d594e094ade141d6ad/src/crawler.cls.php#L829-L832

Debug log:
![](https://user-images.githubusercontent.com/5798637/235984456-27bae6f6-a005-4b87-846b-9580a1c25efc.png)
