### PR TITLE
Add bypass filters litespeed_optm_css_comb_ext_inl, litespeed_optm_js…

### DIFF
--- a/src/media.cls.php
+++ b/src/media.cls.php
@@ -644,7 +644,9 @@ class Media extends Root
 
 			// Add missing dimensions
 			if (defined('LITESPEED_GUEST_OPTM') || $this->conf(Base::O_MEDIA_ADD_MISSING_SIZES)) {
-				if (empty($attrs['width']) || $attrs['width'] == 'auto' || empty($attrs['height']) || $attrs['height'] == 'auto') {
+				if (!apply_filters('litespeed_media_add_missing_sizes', true)) {
+					Debug2::debug2('[Media] add_missing_sizes bypassed via litespeed_media_add_missing_sizes filter');
+				} elseif (empty($attrs['width']) || $attrs['width'] == 'auto' || empty($attrs['height']) || $attrs['height'] == 'auto') {
 					self::debug('⚠️ Missing sizes for image [src] ' . $attrs['src']);
 					$dimensions = $this->_detect_dimensions($attrs['src']);
 					if ($dimensions) {

--- a/src/optimize.cls.php
+++ b/src/optimize.cls.php
@@ -802,6 +802,10 @@ class Optimize extends Base {
 		$excludes = apply_filters( 'litespeed_optimize_js_excludes', $this->conf( self::O_OPTM_JS_EXC ) );
 
 		$combine_ext_inl = $this->conf( self::O_OPTM_JS_COMB_EXT_INL );
+		if ( ! apply_filters( 'litespeed_optm_js_comb_ext_inl', true ) ) {
+			Debug2::debug2( '[Optm] js_comb_ext_inl bypassed via litespeed_optm_js_comb_ext_inl filter' );
+			$combine_ext_inl = false;
+		}
 
 		$src_list = array();
 		$html_list = array();
@@ -973,6 +977,10 @@ class Optimize extends Base {
 		$ucss_file_exc_inline = apply_filters( 'litespeed_optimize_ucss_file_exc_inline', $this->conf( self::O_OPTM_UCSS_FILE_EXC_INLINE ) );
 
 		$combine_ext_inl = $this->conf( self::O_OPTM_CSS_COMB_EXT_INL );
+		if ( ! apply_filters( 'litespeed_optm_css_comb_ext_inl', true ) ) {
+			Debug2::debug2( '[Optm] css_comb_ext_inl bypassed via litespeed_optm_css_comb_ext_inl filter' );
+			$combine_ext_inl = false;
+		}
 
 		$css_to_be_removed = apply_filters( 'litespeed_optm_css_to_be_removed', array() );
 

--- a/src/optimize.cls.php
+++ b/src/optimize.cls.php
@@ -801,9 +801,9 @@ class Optimize extends Base {
 	private function _parse_js() {
 		$excludes = apply_filters( 'litespeed_optimize_js_excludes', $this->conf( self::O_OPTM_JS_EXC ) );
 
-		$combine_ext_inl = $this->conf( self::O_OPTM_JS_COMB_EXT_INL );
-		if ( ! apply_filters( 'litespeed_optm_js_comb_ext_inl', true ) ) {
-			Debug2::debug2( '[Optm] js_comb_ext_inl bypassed via litespeed_optm_js_comb_ext_inl filter' );
+		$combine_ext_inl = $this->conf(self::O_OPTM_JS_COMB_EXT_INL);
+		if (!apply_filters('litespeed_optm_js_comb_ext_inl', true)) {
+			Debug2::debug2('[Optm] js_comb_ext_inl bypassed via litespeed_optm_js_comb_ext_inl filter');
 			$combine_ext_inl = false;
 		}
 
@@ -976,9 +976,9 @@ class Optimize extends Base {
 		$excludes = apply_filters( 'litespeed_optimize_css_excludes', $this->conf( self::O_OPTM_CSS_EXC ) );
 		$ucss_file_exc_inline = apply_filters( 'litespeed_optimize_ucss_file_exc_inline', $this->conf( self::O_OPTM_UCSS_FILE_EXC_INLINE ) );
 
-		$combine_ext_inl = $this->conf( self::O_OPTM_CSS_COMB_EXT_INL );
-		if ( ! apply_filters( 'litespeed_optm_css_comb_ext_inl', true ) ) {
-			Debug2::debug2( '[Optm] css_comb_ext_inl bypassed via litespeed_optm_css_comb_ext_inl filter' );
+		$combine_ext_inl = $this->conf(self::O_OPTM_CSS_COMB_EXT_INL);
+		if (!apply_filters('litespeed_optm_css_comb_ext_inl', true)) {
+			Debug2::debug2('[Optm] css_comb_ext_inl bypassed via litespeed_optm_css_comb_ext_inl filter');
 			$combine_ext_inl = false;
 		}
 


### PR DESCRIPTION
…_comb_ext_inl

These filters allow bypassing combining external/inline CSS and JS.

A third filter allows bypassing Media's "add missing sizes" option (for Guest Optimization and otherwise).