### PR TITLE
Restrict the scope of balloon CSS rules to avoid conflicts

### DIFF
--- a/assets/css/litespeed.css
+++ b/assets/css/litespeed.css
@@ -1874,8 +1874,6 @@ input.litespeed-input-warning {
 	top: 0;
 }
 
-@media screen and (max-width: 1023px) and (min-width: 681px) {}
-
 @media screen and (max-width: 680px) {
 
 	.litespeed-body tbody>tr>th {
@@ -2935,11 +2933,11 @@ g.litespeed-pie_info .litespeed-pie-done {
 	line-height: 1;
 }
 
-span[data-balloon-pos] {
+.litespeed-wrap span[data-balloon-pos] {
 	border-bottom: 1px dashed;
 }
 
-span[aria-label][data-balloon-pos] {
+.litespeed-wrap span[aria-label][data-balloon-pos] {
 	cursor: default;
 }
 
@@ -3555,22 +3553,22 @@ a.litespeed-media-href svg:hover {
 		BALLOON PURE CSS TOOLTIPS
 ======================================= */
 
-:root {
+.litespeed-wrap {
 	--balloon-color: rgba(16, 16, 16, 0.95);
 	--balloon-font-size: 12px;
 	--balloon-move: 4px;
 }
 
-button[aria-label][data-balloon-pos] {
+.litespeed-wrap button[aria-label][data-balloon-pos] {
 	overflow: visible;
 }
 
-[aria-label][data-balloon-pos] {
+.litespeed-wrap [aria-label][data-balloon-pos] {
 	position: relative;
 	cursor: pointer;
 }
 
-[aria-label][data-balloon-pos]:after {
+.litespeed-wrap [aria-label][data-balloon-pos]:after {
 	opacity: 0;
 	pointer-events: none;
 	transition: all .2s ease .05s;
@@ -3591,7 +3589,7 @@ button[aria-label][data-balloon-pos] {
 	line-height: 1.4;
 }
 
-[aria-label][data-balloon-pos]:before {
+.litespeed-wrap [aria-label][data-balloon-pos]:before {
 	width: 0;
 	height: 0;
 	border: 5px solid transparent;
@@ -3604,35 +3602,35 @@ button[aria-label][data-balloon-pos] {
 	z-index: 10;
 }
 
-[aria-label][data-balloon-pos]:hover:before,
-[aria-label][data-balloon-pos]:hover:after,
-[aria-label][data-balloon-pos][data-balloon-visible]:before,
-[aria-label][data-balloon-pos][data-balloon-visible]:after,
-[aria-label][data-balloon-pos]:not([data-balloon-nofocus]):focus:before,
-[aria-label][data-balloon-pos]:not([data-balloon-nofocus]):focus:after {
+.litespeed-wrap [aria-label][data-balloon-pos]:hover:before,
+.litespeed-wrap [aria-label][data-balloon-pos]:hover:after,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-visible]:before,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-visible]:after,
+.litespeed-wrap [aria-label][data-balloon-pos]:not([data-balloon-nofocus]):focus:before,
+.litespeed-wrap [aria-label][data-balloon-pos]:not([data-balloon-nofocus]):focus:after {
 	opacity: 1;
 	pointer-events: none;
 }
 
-[aria-label][data-balloon-pos].font-awesome:after {
+.litespeed-wrap [aria-label][data-balloon-pos].font-awesome:after {
 	font-family: FontAwesome, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
-[aria-label][data-balloon-pos][data-balloon-break]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-break]:after {
 	white-space: pre;
 }
 
-[aria-label][data-balloon-pos][data-balloon-break][data-balloon-length]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-break][data-balloon-length]:after {
 	white-space: pre-line;
 	word-break: break-word;
 }
 
-[aria-label][data-balloon-pos][data-balloon-blunt]:before,
-[aria-label][data-balloon-pos][data-balloon-blunt]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-blunt]:before,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-blunt]:after {
 	transition: none;
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up"]:after {
 	bottom: 100%;
 	left: 50%;
 	margin-bottom: 10px;
@@ -3640,24 +3638,24 @@ button[aria-label][data-balloon-pos] {
 	transform-origin: top;
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up"]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up"]:before {
 	bottom: 100%;
 	left: 50%;
 	transform: translate(-50%, var(--balloon-move));
 	transform-origin: top;
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up"]:hover:after,
-[aria-label][data-balloon-pos][data-balloon-pos="up"][data-balloon-visible]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up"]:hover:after,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up"][data-balloon-visible]:after {
 	transform: translate(-50%, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up"]:hover:before,
-[aria-label][data-balloon-pos][data-balloon-pos="up"][data-balloon-visible]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up"]:hover:before,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up"][data-balloon-visible]:before {
 	transform: translate(-50%, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up-left"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-left"]:after {
 	bottom: 100%;
 	left: 0;
 	margin-bottom: 10px;
@@ -3665,24 +3663,24 @@ button[aria-label][data-balloon-pos] {
 	transform-origin: top;
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up-left"]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-left"]:before {
 	bottom: 100%;
 	left: 5px;
 	transform: translate(0, var(--balloon-move));
 	transform-origin: top;
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up-left"]:hover:after,
-[aria-label][data-balloon-pos][data-balloon-pos="up-left"][data-balloon-visible]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-left"]:hover:after,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-left"][data-balloon-visible]:after {
 	transform: translate(0, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up-left"]:hover:before,
-[aria-label][data-balloon-pos][data-balloon-pos="up-left"][data-balloon-visible]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-left"]:hover:before,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-left"][data-balloon-visible]:before {
 	transform: translate(0, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up-right"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-right"]:after {
 	bottom: 100%;
 	right: 0;
 	margin-bottom: 10px;
@@ -3690,31 +3688,31 @@ button[aria-label][data-balloon-pos] {
 	transform-origin: top;
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up-right"]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-right"]:before {
 	bottom: 100%;
 	right: 5px;
 	transform: translate(0, var(--balloon-move));
 	transform-origin: top;
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up-right"]:hover:after,
-[aria-label][data-balloon-pos][data-balloon-pos="up-right"][data-balloon-visible]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-right"]:hover:after,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-right"][data-balloon-visible]:after {
 	transform: translate(0, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="up-right"]:hover:before,
-[aria-label][data-balloon-pos][data-balloon-pos="up-right"][data-balloon-visible]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-right"]:hover:before,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="up-right"][data-balloon-visible]:before {
 	transform: translate(0, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down"]:after {
 	left: 50%;
 	margin-top: 10px;
 	top: 100%;
 	transform: translate(-50%, calc(var(--balloon-move) * -1));
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down"]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down"]:before {
 	width: 0;
 	height: 0;
 	border: 5px solid transparent;
@@ -3724,24 +3722,24 @@ button[aria-label][data-balloon-pos] {
 	transform: translate(-50%, calc(var(--balloon-move) * -1));
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down"]:hover:after,
-[aria-label][data-balloon-pos][data-balloon-pos="down"][data-balloon-visible]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down"]:hover:after,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down"][data-balloon-visible]:after {
 	transform: translate(-50%, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down"]:hover:before,
-[aria-label][data-balloon-pos][data-balloon-pos="down"][data-balloon-visible]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down"]:hover:before,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down"][data-balloon-visible]:before {
 	transform: translate(-50%, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down-left"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-left"]:after {
 	left: 0;
 	margin-top: 10px;
 	top: 100%;
 	transform: translate(0, calc(var(--balloon-move) * -1));
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down-left"]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-left"]:before {
 	width: 0;
 	height: 0;
 	border: 5px solid transparent;
@@ -3751,24 +3749,24 @@ button[aria-label][data-balloon-pos] {
 	transform: translate(0, calc(var(--balloon-move) * -1));
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down-left"]:hover:after,
-[aria-label][data-balloon-pos][data-balloon-pos="down-left"][data-balloon-visible]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-left"]:hover:after,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-left"][data-balloon-visible]:after {
 	transform: translate(0, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down-left"]:hover:before,
-[aria-label][data-balloon-pos][data-balloon-pos="down-left"][data-balloon-visible]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-left"]:hover:before,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-left"][data-balloon-visible]:before {
 	transform: translate(0, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down-right"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-right"]:after {
 	right: 0;
 	margin-top: 10px;
 	top: 100%;
 	transform: translate(0, calc(var(--balloon-move) * -1));
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down-right"]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-right"]:before {
 	width: 0;
 	height: 0;
 	border: 5px solid transparent;
@@ -3778,24 +3776,24 @@ button[aria-label][data-balloon-pos] {
 	transform: translate(0, calc(var(--balloon-move) * -1));
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down-right"]:hover:after,
-[aria-label][data-balloon-pos][data-balloon-pos="down-right"][data-balloon-visible]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-right"]:hover:after,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-right"][data-balloon-visible]:after {
 	transform: translate(0, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="down-right"]:hover:before,
-[aria-label][data-balloon-pos][data-balloon-pos="down-right"][data-balloon-visible]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-right"]:hover:before,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="down-right"][data-balloon-visible]:before {
 	transform: translate(0, 0);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="left"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="left"]:after {
 	margin-right: 10px;
 	right: 100%;
 	top: 50%;
 	transform: translate(var(--balloon-move), -50%);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="left"]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="left"]:before {
 	width: 0;
 	height: 0;
 	border: 5px solid transparent;
@@ -3805,24 +3803,24 @@ button[aria-label][data-balloon-pos] {
 	transform: translate(var(--balloon-move), -50%);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="left"]:hover:after,
-[aria-label][data-balloon-pos][data-balloon-pos="left"][data-balloon-visible]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="left"]:hover:after,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="left"][data-balloon-visible]:after {
 	transform: translate(0, -50%);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="left"]:hover:before,
-[aria-label][data-balloon-pos][data-balloon-pos="left"][data-balloon-visible]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="left"]:hover:before,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="left"][data-balloon-visible]:before {
 	transform: translate(0, -50%);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="right"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="right"]:after {
 	left: 100%;
 	margin-left: 10px;
 	top: 50%;
 	transform: translate(calc(var(--balloon-move) * -1), -50%);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="right"]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="right"]:before {
 	width: 0;
 	height: 0;
 	border: 5px solid transparent;
@@ -3832,44 +3830,44 @@ button[aria-label][data-balloon-pos] {
 	transform: translate(calc(var(--balloon-move) * -1), -50%);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="right"]:hover:after,
-[aria-label][data-balloon-pos][data-balloon-pos="right"][data-balloon-visible]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="right"]:hover:after,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="right"][data-balloon-visible]:after {
 	transform: translate(0, -50%);
 }
 
-[aria-label][data-balloon-pos][data-balloon-pos="right"]:hover:before,
-[aria-label][data-balloon-pos][data-balloon-pos="right"][data-balloon-visible]:before {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="right"]:hover:before,
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-pos="right"][data-balloon-visible]:before {
 	transform: translate(0, -50%);
 }
 
-[aria-label][data-balloon-pos][data-balloon-length="small"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-length="small"]:after {
 	white-space: normal;
 	width: 80px;
 }
 
-[aria-label][data-balloon-pos][data-balloon-length="medium"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-length="medium"]:after {
 	white-space: normal;
 	width: 150px;
 }
 
-[aria-label][data-balloon-pos][data-balloon-length="large"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-length="large"]:after {
 	white-space: normal;
 	width: 260px;
 }
 
-[aria-label][data-balloon-pos][data-balloon-length="xlarge"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-length="xlarge"]:after {
 	white-space: normal;
 	width: 380px;
 }
 
 @media screen and (max-width: 768px) {
-	[aria-label][data-balloon-pos][data-balloon-length="xlarge"]:after {
+	.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-length="xlarge"]:after {
 		white-space: normal;
 		width: 90vw;
 	}
 }
 
-[aria-label][data-balloon-pos][data-balloon-length="fit"]:after {
+.litespeed-wrap [aria-label][data-balloon-pos][data-balloon-length="fit"]:after {
 	white-space: normal;
 	width: 100%;
 }


### PR DESCRIPTION
Themes like BuddyBoss use balloon tooltips too.
This change prevents style overlaps on the front end when the admin bar is displayed by limiting LiteSpeed balloon styles to descendants of the `.litespeed-wrap` container.