### PR TITLE
Added new hook to _purge_front function

### DIFF
--- a/src/purge.cls.php
+++ b/src/purge.cls.php
@@ -610,6 +610,7 @@ class Purge extends Base {
 
 		$this->purge_url( $_SERVER[ 'HTTP_REFERER' ] );
 
+		do_action( 'litespeed_purged_front', $_SERVER['HTTP_REFERER'] );
 		wp_redirect( $_SERVER[ 'HTTP_REFERER' ] );
 		exit();
 	}


### PR DESCRIPTION
Related to issue #570, this PR adds an hook after an URL is purged when clicking the "Purge this page - LSCache" button