### PR TITLE
Fix in-memory options for multisites

### DIFF
--- a/src/root.cls.php
+++ b/src/root.cls.php
@@ -318,7 +318,7 @@ abstract class Root
 	public function get_options($ori = false)
 	{
 		if (!$ori) {
-			return array_merge(self::$_options, self::$_primary_options, self::$_const_options);
+			return array_merge(self::$_options, self::$_primary_options, self::$_network_options, self::$_const_options);
 		}
 
 		return self::$_options;


### PR DESCRIPTION
Fixes e.g. `Activation->update_files`.

The issue can be observed by turning on/off mobile cache and saving, then viewing `htaccess`.