### PR TITLE
Update js_defer_excludes.txt

### DIFF
--- a/data/js_defer_excludes.txt
+++ b/data/js_defer_excludes.txt
@@ -8,3 +8,9 @@
 stats.wp.com/e-
 _stq
 ## JetPack Stats
+
+##Divi
+scripts.min.js
+et_pb_custom
+salvattore
+easypiechart.js


### PR DESCRIPTION
This allows for the mobile menu hamburger icon to trigger on load, as well as allows the circle, number, and bar counters to function