### PR TITLE
Fix an issue where the admin bar would lose the current screen context

### DIFF
--- a/src/esi.cls.php
+++ b/src/esi.cls.php
@@ -825,6 +825,8 @@ class ESI extends Root
 				}
 			}
 		}
+		// Needed when permalink structure is "Plain"
+		wp();
 
 		wp_admin_bar_render();
 		if (!$this->conf(Base::O_ESI_CACHE_ADMBAR)) {


### PR DESCRIPTION
This happens when Permalink structure is set to "Plain"; every page is incorrectly detected as the homepage.