### PR TITLE
Add direction for Admin Button when Right-To-Left Language

### DIFF
--- a/assets/css/litespeed.css
+++ b/assets/css/litespeed.css
@@ -1162,6 +1162,7 @@ h3 .litespeed-learn-more {
 	margin: 0 0 0;
 	display: inline-flex;
 	position: relative;
+	direction: ltr;
 }
 
 .litespeed-switch input:checked:active + label {


### PR DESCRIPTION
When WordPress Language is RTL for example Arabic.
Lightspeed Admin button is not fix style.

please see Screenshot:
![without-dir](https://github.com/litespeedtech/lscache_wp/assets/949491/3849bd85-09a2-4afc-b33b-7e20a5b2f193)
![with-dir](https://github.com/litespeedtech/lscache_wp/assets/949491/3ad59097-5fb7-4f59-b94e-6b6e4ce33c08)
