### PR TITLE
Fix a dynamic property creation warning

### DIFF
--- a/lib/html-min.cls.php
+++ b/lib/html-min.cls.php
@@ -18,6 +18,11 @@ defined( 'WPINC' ) || exit ;
 class HTML_MIN
 {
 	/**
+	 * @var string
+	 */
+	protected $_html = '';
+
+	/**
 	 * @var boolean
 	 */
 	protected $_jsCleanComments = true;


### PR DESCRIPTION
Fixes #964047:
```
PHP Deprecated: Creation of dynamic property LiteSpeed\Lib\HTML_MIN::$_html is deprecated in .../lib/html-min.cls.php on line 70
```