### PR TITLE
Fix an issue where images won't be pulled with older versions of WordPress

### DIFF
--- a/src/img-optm.cls.php
+++ b/src/img-optm.cls.php
@@ -1134,7 +1134,7 @@ class Img_Optm extends Base
 				$total_pulled_ori++;
 			};
 
-			if (class_exists('\WpOrg\Requests\Requests') && class_exists('\WpOrg\Requests\Autoload') && !version_compare(PHP_VERSION, '5.6.0', '<')) {
+			if (class_exists('\WpOrg\Requests\Requests') && class_exists('\WpOrg\Requests\Autoload') && version_compare(PHP_VERSION, '5.6.0', '>=')) {
 				// Make sure Requests can load internal classes.
 				Autoload::register();
 

--- a/src/img-optm.cls.php
+++ b/src/img-optm.cls.php
@@ -1134,7 +1134,7 @@ class Img_Optm extends Base
 				$total_pulled_ori++;
 			};
 
-			if (class_exists('\WpOrg\Requests\Requests') && class_exists('\WpOrg\Requests\Autoload')) {
+			if (class_exists('\WpOrg\Requests\Requests') && class_exists('\WpOrg\Requests\Autoload') && !version_compare(PHP_VERSION, '5.6.0', '<')) {
 				// Make sure Requests can load internal classes.
 				Autoload::register();
 

--- a/src/img-optm.cls.php
+++ b/src/img-optm.cls.php
@@ -1031,7 +1031,17 @@ class Img_Optm extends Base
 					} else {
 						// handle error
 						$image_url = $server_info['server'] . '/' . $server_info[$row_type];
-						self::debug('❌ failed to pull image (' . $row_type . '): ' . (!empty($response->status_code) ? $response->status_code : '') . ' [Local: ' . $row_img->src . '] / [remote: ' . $image_url . ']');
+						self::debug(
+							'❌ failed to pull image (' .
+								$row_type .
+								'): ' .
+								(!empty($response->status_code) ? $response->status_code : '') .
+								' [Local: ' .
+								$row_img->src .
+								'] / [remote: ' .
+								$image_url .
+								']'
+						);
 						return;
 					}
 				}
@@ -1161,9 +1171,9 @@ class Img_Optm extends Base
 		// Notify IAPI images taken
 		foreach ($server_list as $server => $img_list) {
 			$data = array(
-				'action'	=> self::CLOUD_ACTION_TAKEN,
-				'list' 		=> $img_list,
-				'server'	=> $server,
+				'action' => self::CLOUD_ACTION_TAKEN,
+				'list' => $img_list,
+				'server' => $server,
 			);
 			// TODO: improve this so we do not call once per server, but just once and then filter on the server side
 			Cloud::post(Cloud::SVC_IMG_OPTM, $data);
@@ -2052,10 +2062,10 @@ class Img_Optm extends Base
 				self::start_async();
 				break;
 
-				/**
-				 * Batch switch
-				 * @since 1.6.3
-				 */
+			/**
+			 * Batch switch
+			 * @since 1.6.3
+			 */
 			case self::TYPE_BATCH_SWITCH_ORI:
 			case self::TYPE_BATCH_SWITCH_OPTM:
 				$this->_batch_switch($type);

--- a/src/img-optm.cls.php
+++ b/src/img-optm.cls.php
@@ -1134,7 +1134,7 @@ class Img_Optm extends Base
 				$total_pulled_ori++;
 			};
 
-			if (class_exists('Requests')) {
+			if (class_exists('\WpOrg\Requests\Requests') && class_exists('\WpOrg\Requests\Autoload')) {
 				// Make sure Requests can load internal classes.
 				Autoload::register();
 


### PR DESCRIPTION
- The `Requests` class didn't always exist at the current namespace.
- The `Autoload` class is a fairly recent addition.

Additionally, the `Requests` class doesn't support all the oldest PHP versions that LSCWP does.

This PR should limit parallel pull to only the most recent versions of WordPress.

Additionally, parallel pull won't be used for PHP < v5.6, as per the Requests [changelog](https://github.com/WordPress/Requests/blob/681bc0553859e650125f562276dbcaf5325eaf31/CHANGELOG.md?plain=1#L123)