### PR TITLE
Support async attribute in non-HTML5 script tags

### DIFF
--- a/src/optimize.cls.php
+++ b/src/optimize.cls.php
@@ -1227,7 +1227,7 @@ class Optimize extends Base
 	private function _js_defer($ori, $src)
 	{
 		if (strpos($ori, ' async') !== false) {
-			$ori = str_replace(' async', '', $ori);
+			$ori = preg_replace('# async(?:=([\'"])(?:[^\1]+)\1)?#isU', '', $ori);
 		}
 
 		if (strpos($ori, 'defer') !== false) {


### PR DESCRIPTION
When a theme doesn't declare support for HTML5 scripts, WordPress outputs the code like this:

```html
<script type="text/javascript" src="https://.../wp-includes/assets/js/comment-reply.min.js" id="comment-reply-js" async="async" data-wp-strategy="async"></script>
```

The tag currently gets incorrectly rewritten to:

```html
<script data-optimized="1" type="litespeed/javascript" data-src="https://.../wp-content/litespeed/js/generatedname.js?ver=hash" id="comment-reply-js"="async" data-wp-strategy="async"></script>
```

With this change, users shouldn't have to e.g.

```php
add_action( 'after_setup_theme', function() {
   add_theme_support( 'html5', [ 'script' ] );
}, 10 );
```