### PR TITLE
Return false when Redis fails to set a value

### DIFF
--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -469,6 +469,7 @@ class Object_Cache extends Root
 			try {
 				$res = $this->_conn->setEx($key, $ttl, $data);
 			} catch (\RedisException $ex) {
+				$res = false;
 				$msg = sprintf(__('Redis encountered a fatal error: %s (code: %d)', 'litespeed-cache'), $ex->getMessage(), $ex->getCode());
 				Debug2::debug('[Object] ' . $msg);
 				Admin_Display::error($msg);


### PR DESCRIPTION
Addresses the following issue.

```
Undefined variable $res in /.../src/object-cache.cls.php on line 480
```