### PR TITLE
Added new settings

### DIFF
--- a/src/base.cls.php
+++ b/src/base.cls.php
@@ -71,6 +71,7 @@ class Base extends Root
 	## --------------		Purge 		----------------- ##
 	## -------------------------------------------------- ##
 	const O_PURGE_ON_UPGRADE = 'purge-upgrade';
+	const O_PURGE_GUEST_PAGES = 'purge-guest_pages';
 	const O_PURGE_STALE = 'purge-stale';
 	const O_PURGE_POST_ALL = 'purge-post_all';
 	const O_PURGE_POST_FRONTPAGE = 'purge-post_f';
@@ -140,6 +141,7 @@ class Base extends Root
 	const O_OPTM_JS_EXC = 'optm-js_exc';
 	const O_OPTM_HTML_MIN = 'optm-html_min';
 	const O_OPTM_HTML_LAZY = 'optm-html_lazy';
+	const O_OPTM_HTML_SKIP_COMMENTS = 'optm-html_skip_comment';
 	const O_OPTM_QS_RM = 'optm-qs_rm';
 	const O_OPTM_GGFONTS_RM = 'optm-ggfonts_rm';
 	const O_OPTM_CSS_ASYNC = 'optm-css_async';
@@ -232,6 +234,7 @@ class Base extends Root
 	## --------------		Crawler		----------------- ##
 	## -------------------------------------------------- ##
 	const O_CRAWLER = 'crawler';
+	const O_CRAWLER_SCHEDULE_TIME = 'crawler-schedule_time';
 	const O_CRAWLER_USLEEP = 'crawler-usleep';
 	const O_CRAWLER_RUN_DURATION = 'crawler-run_duration';
 	const O_CRAWLER_RUN_INTERVAL = 'crawler-run_interval';
@@ -308,6 +311,7 @@ class Base extends Root
 	protected static $SINGLE_SITE_OPTIONS = array(
 		self::O_API_KEY,
 		self::O_CRAWLER,
+		self::O_CRAWLER_SCHEDULE_TIME,
 		self::O_CRAWLER_SITEMAP,
 		self::O_CRAWLER_DROP_DOMAIN,
 		self::O_CDN,
@@ -373,6 +377,7 @@ class Base extends Root
 
 		// Purge
 		self::O_PURGE_ON_UPGRADE => false,
+		self::O_PURGE_GUEST_PAGES => true,
 		self::O_PURGE_STALE => false,
 		self::O_PURGE_POST_ALL => false,
 		self::O_PURGE_POST_FRONTPAGE => false,
@@ -432,6 +437,7 @@ class Base extends Root
 		self::O_OPTM_JS_EXC => array(),
 		self::O_OPTM_HTML_MIN => false,
 		self::O_OPTM_HTML_LAZY => array(),
+		self::O_OPTM_HTML_SKIP_COMMENTS => '',
 		self::O_OPTM_QS_RM => false,
 		self::O_OPTM_GGFONTS_RM => false,
 		self::O_OPTM_CSS_ASYNC => false,
@@ -514,6 +520,7 @@ class Base extends Root
 
 		// Crawler
 		self::O_CRAWLER => false,
+		self::O_CRAWLER_SCHEDULE_TIME => '00:00-23:59',
 		self::O_CRAWLER_USLEEP => 0,
 		self::O_CRAWLER_RUN_DURATION => 0,
 		self::O_CRAWLER_RUN_INTERVAL => 0,

--- a/src/lang.cls.php
+++ b/src/lang.cls.php
@@ -46,12 +46,12 @@ class Lang extends Base
 	{
 		$map = array(
 			'auto_alias_failed_cdn' =>
-				__('Unable to automatically add %1$s as a Domain Alias for main %2$s domain, due to potential CDN conflict.', 'litespeed-cache') .
+			__('Unable to automatically add %1$s as a Domain Alias for main %2$s domain, due to potential CDN conflict.', 'litespeed-cache') .
 				' ' .
 				Doc::learn_more('https://quic.cloud/docs/cdn/dns/how-to-setup-domain-alias/', false, false, false, true),
 
 			'auto_alias_failed_uid' =>
-				__('Unable to automatically add %1$s as a Domain Alias for main %2$s domain.', 'litespeed-cache') .
+			__('Unable to automatically add %1$s as a Domain Alias for main %2$s domain.', 'litespeed-cache') .
 				' ' .
 				__('Alias is in use by another QUIC.cloud account.', 'litespeed-cache') .
 				' ' .
@@ -130,6 +130,7 @@ class Lang extends Base
 			self::O_OBJECT_TRANSIENTS => __('Store Transients', 'litespeed-cache'),
 
 			self::O_PURGE_ON_UPGRADE => __('Purge All On Upgrade', 'litespeed-cache'),
+			self::O_PURGE_GUEST_PAGES => __('Purge guest pages on Purge all', 'litespeed-cache'),
 			self::O_PURGE_STALE => __('Serve Stale', 'litespeed-cache'),
 			self::O_PURGE_TIMED_URLS => __('Scheduled Purge URLs', 'litespeed-cache'),
 			self::O_PURGE_TIMED_URLS_TIME => __('Scheduled Purge Time', 'litespeed-cache'),
@@ -153,6 +154,7 @@ class Lang extends Base
 			self::O_OPTM_JS_COMB_EXT_INL => __('JS Combine External and Inline', 'litespeed-cache'),
 			self::O_OPTM_HTML_MIN => __('HTML Minify', 'litespeed-cache'),
 			self::O_OPTM_HTML_LAZY => __('HTML Lazy Load Selectors', 'litespeed-cache'),
+			self::O_OPTM_HTML_SKIP_COMMENTS => __('HTML Keep commnents', 'litespeed-cache'),
 			self::O_OPTM_CSS_ASYNC => __('Load CSS Asynchronously', 'litespeed-cache'),
 			self::O_OPTM_CCSS_PER_URL => __('CCSS Per URL', 'litespeed-cache'),
 			self::O_OPTM_CSS_ASYNC_INLINE => __('Inline CSS Async Lib', 'litespeed-cache'),
@@ -251,6 +253,7 @@ class Lang extends Base
 			self::O_CDN_CLOUDFLARE => __('Cloudflare API', 'litespeed-cache'),
 
 			self::O_CRAWLER => __('Crawler', 'litespeed-cache'),
+			self::O_CRAWLER_SCHEDULE_TIME => __('Running time', 'litespeed-cache'),
 			self::O_CRAWLER_USLEEP => __('Delay', 'litespeed-cache'),
 			self::O_CRAWLER_RUN_DURATION => __('Run Duration', 'litespeed-cache'),
 			self::O_CRAWLER_RUN_INTERVAL => __('Interval Between Runs', 'litespeed-cache'),

--- a/src/optimizer.cls.php
+++ b/src/optimizer.cls.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The optimize4 class.
  *
@@ -7,6 +8,7 @@
  * @subpackage 	LiteSpeed/inc
  * @author     	LiteSpeed Technologies <info@litespeedtech.com>
  */
+
 namespace LiteSpeed;
 
 defined('WPINC') || exit();
@@ -44,22 +46,27 @@ class Optimizer extends Root
 			$options['jsMinifier'] = __CLASS__ . '::minify_js';
 		}
 
+		$skip_comments = $this->conf(Base::O_OPTM_HTML_SKIP_COMMENTS, '');
+		if (!empty($skip_comments)) {
+			$options['skipComments'] = $skip_comments;
+		}
+
 		/**
 		 * Added exception capture when minify
 		 * @since  2.2.3
 		 */
-		try {
-			$obj = new Lib\HTML_MIN($content, $options);
-			$content_final = $obj->process();
-			if (!defined('LSCACHE_ESI_SILENCE')) {
-				$content_final .= "\n" . '<!-- Page optimized by LiteSpeed Cache @' . date('Y-m-d H:i:s', time() + LITESPEED_TIME_OFFSET) . ' -->';
-			}
-			return $content_final;
-		} catch (\Exception $e) {
-			Debug2::debug('******[Optmer] html_min failed: ' . $e->getMessage());
-			error_log('****** LiteSpeed Optimizer html_min failed: ' . $e->getMessage());
-			return $content;
+		//try {
+		$obj = new Lib\HTML_MIN($content, $options);
+		$content_final = $obj->process();
+		if (!defined('LSCACHE_ESI_SILENCE')) {
+			$content_final .= "\n" . '<!-- Page optimized by LiteSpeed Cache @' . date('Y-m-d H:i:s', time() + LITESPEED_TIME_OFFSET) . ' -->';
 		}
+		return $content_final;
+		// } catch (\Exception $e) {
+		// 	Debug2::debug('******[Optmer] html_min failed: ' . $e->getMessage());
+		// 	error_log('****** LiteSpeed Optimizer html_min failed: ' . $e->getMessage());
+		// 	return $content;
+		// }
 	}
 
 	/**

--- a/src/purge.cls.php
+++ b/src/purge.cls.php
@@ -192,7 +192,22 @@ class Purge extends Base
 		// 	self::debug( 'CLI request, queue stored: ' . $curr_built );
 		// }
 		// else {
-		$this->_purge_all_lscache(true);
+
+		$purge_guest = $this->conf(BASE::O_PURGE_GUEST_PAGES);
+		if ($purge_guest) {
+			$this->_purge_all_lscache(true);
+		}
+		//  else {
+		// 	$this->_add(Tag::TYPE_LOCALRES);
+		// 	$this->_add(Tag::TYPE_HTTP);
+		// 	$this->_add(Tag::TYPE_MIN);
+		// 	// $this->_add(Tag::TYPE_FRONTPAGE);
+		// 	// if (LITESPEED_SERVER_TYPE !== 'LITESPEED_SERVER_OLS') {
+		// 	// 	$this->_add_private(Tag::TYPE_FRONTPAGE);
+		// 	// }
+		// 	// $this->_add(Tag::TYPE_PAGES);
+		// }
+
 		$this->_purge_all_cssjs(true);
 		$this->_purge_all_localres(true);
 		// $this->_purge_all_ccss( true );

--- a/src/router.cls.php
+++ b/src/router.cls.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The core plugin router class.
  *
@@ -7,7 +8,9 @@
  * @since      	1.1.0
  * @since  		1.5 Moved into /inc
  */
+
 namespace LiteSpeed;
+
 defined('WPINC') || exit();
 
 class Router extends Base
@@ -540,7 +543,7 @@ class Router extends Base
 		$_can_option = current_user_can('manage_options');
 
 		switch ($action) {
-			// Save network settings
+				// Save network settings
 			case self::ACTION_SAVE_SETTINGS_NETWORK:
 				if ($_can_network_option) {
 					self::$_action = $action;

--- a/tpl/cache/settings-cache.tpl.php
+++ b/tpl/cache/settings-cache.tpl.php
@@ -1,155 +1,161 @@
 <?php
+
 namespace LiteSpeed;
-defined( 'WPINC' ) || exit;
+
+defined('WPINC') || exit;
 ?>
 
 <h3 class="litespeed-title-short">
-	<?php echo __( 'Cache Control Settings', 'litespeed-cache' ); ?>
-	<?php Doc::learn_more( 'https://docs.litespeedtech.com/lscache/lscwp/cache/' ); ?>
+	<?php echo __('Cache Control Settings', 'litespeed-cache'); ?>
+	<?php Doc::learn_more('https://docs.litespeedtech.com/lscache/lscwp/cache/'); ?>
 </h3>
 
-<table class="wp-list-table striped litespeed-table"><tbody>
-	<tr>
-		<th>
-			<?php $id = Base::O_CACHE; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-			<?php if ( $this->_is_multisite ) : ?>
-				<?php $this->build_switch( $id, array( __( 'OFF', 'litespeed-cache' ), __( 'ON', 'litespeed-cache' ), __( 'Use Network Admin Setting', 'litespeed-cache' ) ) ); ?>
-			<?php else : ?>
-				<?php $this->build_switch( $id ); ?>
-			<?php endif; ?>
-			<div class="litespeed-desc">
-				<?php echo sprintf(__('Please visit the <a %s>Information</a> page on how to test the cache.', 'litespeed-cache'),
-					'href="https://docs.litespeedtech.com/lscache/lscwp/installation/#testing" target="_blank"'); ?>
-
-				<strong><?php echo __('NOTICE', 'litespeed-cache'); ?>: </strong><?php echo __('When disabling the cache, all cached entries for this site will be purged.', 'litespeed-cache'); ?>
-
-				<?php if ( $this->_is_multisite ): ?>
-				<br><?php echo __('The network admin setting can be overridden here.', 'litespeed-cache'); ?>
+<table class="wp-list-table striped litespeed-table">
+	<tbody>
+		<tr>
+			<th>
+				<?php $id = Base::O_CACHE; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php if ($this->_is_multisite) : ?>
+					<?php $this->build_switch($id, array(__('OFF', 'litespeed-cache'), __('ON', 'litespeed-cache'), __('Use Network Admin Setting', 'litespeed-cache'))); ?>
+				<?php else : ?>
+					<?php $this->build_switch($id); ?>
 				<?php endif; ?>
+				<div class="litespeed-desc">
+					<?php echo sprintf(
+						__('Please visit the <a %s>Information</a> page on how to test the cache.', 'litespeed-cache'),
+						'href="https://docs.litespeedtech.com/lscache/lscwp/installation/#testing" target="_blank"'
+					); ?>
 
-				<?php if ( ! $this->conf( Base::O_CACHE ) && $this->conf( Base::O_CDN_QUIC ) ): ?>
-				<br><font class="litespeed-success"><?php echo __( 'With QUIC.cloud CDN enabled, you may still be seeing cache headers from your local server.', 'litespeed-cache' ); ?></font>
-				<?php endif; ?>
-			</div>
-		</td>
-	</tr>
+					<strong><?php echo __('NOTICE', 'litespeed-cache'); ?>: </strong><?php echo __('When disabling the cache, all cached entries for this site will be purged.', 'litespeed-cache'); ?>
 
-	<tr>
-		<th>
-			<?php $id = Base::O_CACHE_PRIV; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-			<?php $this->build_switch( $id ); ?>
-			<div class="litespeed-desc">
-				<?php echo sprintf( __( 'Privately cache frontend pages for logged-in users. (LSWS %s required)', 'litespeed-cache' ), 'v5.2.1+' ); ?>
-			</div>
-		</td>
-	</tr>
+					<?php if ($this->_is_multisite) : ?>
+						<br><?php echo __('The network admin setting can be overridden here.', 'litespeed-cache'); ?>
+					<?php endif; ?>
 
-	<tr>
-		<th>
-			<?php $id = Base::O_CACHE_COMMENTER; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-			<?php $this->build_switch( $id ); ?>
-			<div class="litespeed-desc">
-				<?php echo sprintf( __( 'Privately cache commenters that have pending comments. Disabling this option will serve non-cacheable pages to commenters. (LSWS %s required)', 'litespeed-cache' ), 'v5.2.1+' ); ?>
-			</div>
-		</td>
-	</tr>
+					<?php if (!$this->conf(Base::O_CACHE) && $this->conf(Base::O_CDN_QUIC)) : ?>
+						<br>
+						<font class="litespeed-success"><?php echo __('With QUIC.cloud CDN enabled, you may still be seeing cache headers from your local server.', 'litespeed-cache'); ?></font>
+					<?php endif; ?>
+				</div>
+			</td>
+		</tr>
 
-	<tr>
-		<th>
-			<?php $id = Base::O_CACHE_REST; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-			<?php $this->build_switch( $id ); ?>
-			<div class="litespeed-desc">
-				<?php echo __( 'Cache requests made by WordPress REST API calls.', 'litespeed-cache' ); ?>
-			</div>
-		</td>
-	</tr>
+		<tr>
+			<th>
+				<?php $id = Base::O_CACHE_PRIV; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_switch($id); ?>
+				<div class="litespeed-desc">
+					<?php echo sprintf(__('Privately cache frontend pages for logged-in users. (LSWS %s required)', 'litespeed-cache'), 'v5.2.1+'); ?>
+				</div>
+			</td>
+		</tr>
 
-	<tr>
-		<th>
-			<?php $id = Base::O_CACHE_PAGE_LOGIN; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-			<?php $this->build_switch( $id ); ?>
-			<div class="litespeed-desc">
-				<?php echo __( 'Disabling this option may negatively affect performance.', 'litespeed-cache' ); ?>
-			</div>
-		</td>
-	</tr>
+		<tr>
+			<th>
+				<?php $id = Base::O_CACHE_COMMENTER; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_switch($id); ?>
+				<div class="litespeed-desc">
+					<?php echo sprintf(__('Privately cache commenters that have pending comments. Disabling this option will serve non-cacheable pages to commenters. (LSWS %s required)', 'litespeed-cache'), 'v5.2.1+'); ?>
+				</div>
+			</td>
+		</tr>
 
-	<?php
-		if ( ! $this->_is_multisite ) :
+		<tr>
+			<th>
+				<?php $id = Base::O_CACHE_REST; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_switch($id); ?>
+				<div class="litespeed-desc">
+					<?php echo __('Cache requests made by WordPress REST API calls.', 'litespeed-cache'); ?>
+				</div>
+			</td>
+		</tr>
+
+		<tr>
+			<th>
+				<?php $id = Base::O_CACHE_PAGE_LOGIN; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_switch($id); ?>
+				<div class="litespeed-desc">
+					<?php echo __('Disabling this option may negatively affect performance.', 'litespeed-cache'); ?>
+				</div>
+			</td>
+		</tr>
+
+		<?php
+		if (!$this->_is_multisite) :
 			require LSCWP_DIR . 'tpl/cache/settings_inc.cache_favicon.tpl.php';
 			require LSCWP_DIR . 'tpl/cache/settings_inc.cache_resources.tpl.php';
 			require LSCWP_DIR . 'tpl/cache/settings_inc.cache_mobile.tpl.php';
 		endif;
-	?>
+		?>
 
-	<tr>
-		<th>
-			<?php $id = Base::O_CACHE_PRIV_URI; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-			<?php $this->build_textarea( $id ); ?>
-			<div class="litespeed-desc">
-				<?php echo __( 'URI Paths containing these strings will NOT be cached as public.', 'litespeed-cache' ); ?>
-				<?php $this->_uri_usage_example(); ?>
-			</div>
-		</td>
-	</tr>
+		<tr>
+			<th>
+				<?php $id = Base::O_CACHE_PRIV_URI; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_textarea($id); ?>
+				<div class="litespeed-desc">
+					<?php echo __('URI Paths containing these strings will NOT be cached as public.', 'litespeed-cache'); ?>
+					<?php $this->_uri_usage_example(); ?>
+				</div>
+			</td>
+		</tr>
 
-	<tr>
-		<th>
-			<?php $id = Base::O_CACHE_FORCE_URI; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-			<?php $this->build_textarea( $id ); ?>
-			<div class="litespeed-desc">
-				<?php echo __( 'Paths containing these strings will be cached regardless of no-cacheable settings.', 'litespeed-cache' ); ?>
-				<?php $this->_uri_usage_example(); ?>
-				<br /><?php echo __( 'To define a custom TTL for a URI, add a space followed by the TTL value to the end of the URI.', 'litespeed-cache' ); ?>
-				<?php echo sprintf( __( 'For example, %1$s defines a TTL of %2$s seconds for %3$s.', 'litespeed-cache' ), '<code>/mypath/mypage 300</code>', 300, '<code>/mypath/mypage</code>' ); ?>
-				<?php Doc::one_per_line(); ?>
-			</div>
-		</td>
-	</tr>
+		<tr>
+			<th>
+				<?php $id = Base::O_CACHE_FORCE_URI; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_textarea($id); ?>
+				<div class="litespeed-desc">
+					<?php echo __('Paths containing these strings will be cached regardless of no-cacheable settings.', 'litespeed-cache'); ?>
+					<?php $this->_uri_usage_example(); ?>
+					<br /><?php echo __('To define a custom TTL for a URI, add a space followed by the TTL value to the end of the URI.', 'litespeed-cache'); ?>
+					<?php echo sprintf(__('For example, %1$s defines a TTL of %2$s seconds for %3$s.', 'litespeed-cache'), '<code>/mypath/mypage 300</code>', 300, '<code>/mypath/mypage</code>'); ?>
+					<?php Doc::one_per_line(); ?>
+				</div>
+			</td>
+		</tr>
 
-	<tr>
-		<th>
-			<?php $id = Base::O_CACHE_FORCE_PUB_URI; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-			<?php $this->build_textarea( $id ); ?>
-			<div class="litespeed-desc">
-				<?php echo __( 'Paths containing these strings will be forced to public cached regardless of no-cacheable settings.', 'litespeed-cache' ); ?>
-				<?php $this->_uri_usage_example(); ?>
-				<br /><?php echo __( 'To define a custom TTL for a URI, add a space followed by the TTL value to the end of the URI.', 'litespeed-cache' ); ?>
-				<?php echo sprintf( __( 'For example, %1$s defines a TTL of %2$s seconds for %3$s.', 'litespeed-cache' ), '<code>/mypath/mypage 300</code>', 300, '<code>/mypath/mypage</code>' ); ?>
-				<?php Doc::one_per_line(); ?>
-			</div>
-		</td>
-	</tr>
+		<tr>
+			<th>
+				<?php $id = Base::O_CACHE_FORCE_PUB_URI; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_textarea($id); ?>
+				<div class="litespeed-desc">
+					<?php echo __('Paths containing these strings will be forced to public cached regardless of no-cacheable settings.', 'litespeed-cache'); ?>
+					<?php $this->_uri_usage_example(); ?>
+					<br /><?php echo __('To define a custom TTL for a URI, add a space followed by the TTL value to the end of the URI.', 'litespeed-cache'); ?>
+					<?php echo sprintf(__('For example, %1$s defines a TTL of %2$s seconds for %3$s.', 'litespeed-cache'), '<code>/mypath/mypage 300</code>', 300, '<code>/mypath/mypage</code>'); ?>
+					<?php Doc::one_per_line(); ?>
+				</div>
+			</td>
+		</tr>
 
-	<?php
-		if ( ! $this->_is_multisite ) :
+		<?php
+		if (!$this->_is_multisite) :
 			require LSCWP_DIR . 'tpl/cache/settings_inc.cache_dropquery.tpl.php';
 		endif;
-	?>
+		?>
 
-</tbody></table>
-
+	</tbody>
+</table>

--- a/tpl/cache/settings-purge.tpl.php
+++ b/tpl/cache/settings-purge.tpl.php
@@ -1,30 +1,32 @@
 <?php
+
 namespace LiteSpeed;
-defined( 'WPINC' ) || exit;
+
+defined('WPINC') || exit;
 ?>
 
 <h3 class="litespeed-title-short">
-	<?php echo __( 'Purge Settings', 'litespeed-cache' ); ?>
-	<?php Doc::learn_more( 'https://docs.litespeedtech.com/lscache/lscwp/cache/#purge-tab' ); ?>
+	<?php echo __('Purge Settings', 'litespeed-cache'); ?>
+	<?php Doc::learn_more('https://docs.litespeedtech.com/lscache/lscwp/cache/#purge-tab'); ?>
 </h3>
 
 <?php
 $option_list = array(
-	Base::O_PURGE_POST_ALL => __( 'All pages', 'litespeed-cache' ),
-	Base::O_PURGE_POST_FRONTPAGE => __( 'Front page', 'litespeed-cache' ),
-	Base::O_PURGE_POST_HOMEPAGE => __( 'Home page', 'litespeed-cache' ),
-	Base::O_PURGE_POST_PAGES => __( 'Pages', 'litespeed-cache' ),
+	Base::O_PURGE_POST_ALL => __('All pages', 'litespeed-cache'),
+	Base::O_PURGE_POST_FRONTPAGE => __('Front page', 'litespeed-cache'),
+	Base::O_PURGE_POST_HOMEPAGE => __('Home page', 'litespeed-cache'),
+	Base::O_PURGE_POST_PAGES => __('Pages', 'litespeed-cache'),
 
-	Base::O_PURGE_POST_PAGES_WITH_RECENT_POSTS => __( 'All pages with Recent Posts Widget', 'litespeed-cache' ),
+	Base::O_PURGE_POST_PAGES_WITH_RECENT_POSTS => __('All pages with Recent Posts Widget', 'litespeed-cache'),
 
-	Base::O_PURGE_POST_AUTHOR => __( 'Author archive', 'litespeed-cache' ),
-	Base::O_PURGE_POST_POSTTYPE => __( 'Post type archive', 'litespeed-cache' ),
+	Base::O_PURGE_POST_AUTHOR => __('Author archive', 'litespeed-cache'),
+	Base::O_PURGE_POST_POSTTYPE => __('Post type archive', 'litespeed-cache'),
 
-	Base::O_PURGE_POST_YEAR => __( 'Yearly archive', 'litespeed-cache' ),
-	Base::O_PURGE_POST_MONTH => __( 'Monthly archive', 'litespeed-cache' ),
-	Base::O_PURGE_POST_DATE => __( 'Daily archive', 'litespeed-cache' ),
+	Base::O_PURGE_POST_YEAR => __('Yearly archive', 'litespeed-cache'),
+	Base::O_PURGE_POST_MONTH => __('Monthly archive', 'litespeed-cache'),
+	Base::O_PURGE_POST_DATE => __('Daily archive', 'litespeed-cache'),
 
-	Base::O_PURGE_POST_TERM => __( 'Term archive (include category, tag, and tax)', 'litespeed-cache' ),
+	Base::O_PURGE_POST_TERM => __('Term archive (include category, tag, and tax)', 'litespeed-cache'),
 );
 
 // break line at these ids
@@ -37,125 +39,136 @@ $break_arr = array(
 
 ?>
 
-<table class="wp-list-table striped litespeed-table"><tbody>
+<table class="wp-list-table striped litespeed-table">
+	<tbody>
 
-	<?php if ( ! $this->_is_multisite ) : ?>
-		<?php require LSCWP_DIR . 'tpl/cache/settings_inc.purge_on_upgrade.tpl.php'; ?>
-	<?php endif; ?>
+		<?php if (!$this->_is_multisite) : ?>
+			<?php require LSCWP_DIR . 'tpl/cache/settings_inc.purge_on_upgrade.tpl.php'; ?>
+		<?php endif; ?>
 
-	<tr>
-		<th><?php echo __( 'Auto Purge Rules For Publish/Update', 'litespeed-cache' ); ?></th>
-		<td>
-			<div class="litespeed-callout notice notice-warning inline">
-				<h4><?php echo __( 'Note', 'litespeed-cache' ); ?></h4>
-				<p>
-					<?php echo __( 'Select "All" if there are dynamic widgets linked to posts on pages other than the front or home pages.', 'litespeed-cache' ); ?><br />
-					<?php echo __( 'Other checkboxes will be ignored.', 'litespeed-cache' ); ?><br />
-					<?php echo __( 'Select only the archive types that are currently used, the others can be left unchecked.', 'litespeed-cache' ); ?>
-				</p>
-			</div>
-			<div class="litespeed-top20">
-				<div class="litespeed-tick-wrapper">
-					<?php
-						foreach ( $option_list as $id => $title ) {
+		<tr>
+			<th>
+				<?php $id = Base::O_PURGE_GUEST_PAGES; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_switch($id); ?>
+			</td>
+		</tr>
 
-							$this->build_checkbox( $id, $title );
+		<tr>
+			<th><?php echo __('Auto Purge Rules For Publish/Update', 'litespeed-cache'); ?></th>
+			<td>
+				<div class="litespeed-callout notice notice-warning inline">
+					<h4><?php echo __('Note', 'litespeed-cache'); ?></h4>
+					<p>
+						<?php echo __('Select "All" if there are dynamic widgets linked to posts on pages other than the front or home pages.', 'litespeed-cache'); ?><br />
+						<?php echo __('Other checkboxes will be ignored.', 'litespeed-cache'); ?><br />
+						<?php echo __('Select only the archive types that are currently used, the others can be left unchecked.', 'litespeed-cache'); ?>
+					</p>
+				</div>
+				<div class="litespeed-top20">
+					<div class="litespeed-tick-wrapper">
+						<?php
+						foreach ($option_list as $id => $title) {
 
-							if ( in_array( $id, $break_arr ) ) {
+							$this->build_checkbox($id, $title);
+
+							if (in_array($id, $break_arr)) {
 								echo '</div><div class="litespeed-tick-wrapper litespeed-top10">';
 							}
 						}
-					?>
+						?>
+					</div>
 				</div>
-			</div>
-			<div class="litespeed-desc">
-				<?php echo __( 'Select which pages will be automatically purged when posts are published/updated.', 'litespeed-cache' ); ?>
-			</div>
-		</td>
-	</tr>
-
-	<tr>
-		<th>
-			<?php $id = Base::O_PURGE_STALE; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-			<?php $this->build_switch( $id ); ?>
-			<div class="litespeed-desc">
-				<?php echo __( 'If ON, the stale copy of a cached page will be shown to visitors until a new cache copy is available. Reduces the server load for following visits. If OFF, the page will be dynamically generated while visitors wait.', 'litespeed-cache' ); ?>
-				<?php Doc::learn_more( 'https://docs.litespeedtech.com/lscache/lscwp/cache/#serve-stale' ); ?>
-			</div>
-			<div class="litespeed-callout notice notice-warning inline">
-				<h4><?php echo __( 'Note', 'litespeed-cache' ); ?></h4>
-				<p>
-					<?php echo __( 'By design, this option may serve stale content. Do not enable this option, if that is not OK with you.', 'litespeed-cache' ); ?><br />
-				</p>
-			</div>
-		</td>
-	</tr>
-
-	<tr>
-		<th>
-			<?php $id = Base::O_PURGE_TIMED_URLS; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-			<?php $this->build_textarea( $id, 80 ); ?>
-			<div class="litespeed-desc">
-				<?php echo sprintf( __( 'The URLs here (one per line) will be purged automatically at the time set in the option "%s".', 'litespeed-cache' ), __( 'Scheduled Purge Time', 'litespeed-cache' ) ); ?><br />
-				<?php echo sprintf( __( 'Both %1$s and %2$s are acceptable.', 'litespeed-cache' ), '<code>http://www.example.com/path/url.php</code>', '<code>/path/url.php</code>' ); ?>
-				<?php Doc::one_per_line(); ?>
-			</div>
-			<div class="litespeed-desc">
-				<?php echo sprintf( __( 'Wildcard %1$s supported (match zero or more characters). For example, to match %2$s and %3$s, use %4$s.', 'litespeed-cache' ), '<code>*</code>', '<code>/path/u-1.html</code>', '<code>/path/u-2.html</code>', '<code>/path/u-*.html</code>' ); ?>
-			</div>
-			<div class="litespeed-callout notice notice-warning inline">
-				<h4><?php echo __( 'Note', 'litespeed-cache' ); ?></h4>
-				<p>
-					<?php echo __( 'For URLs with wildcards, there may be a delay in initiating scheduled purge.', 'litespeed-cache' ); ?><br />
-					<?php Doc::learn_more( 'https://docs.litespeedtech.com/lscache/lscwp/cache/#scheduled-purge-urls' ); ?>
-				</p>
-			</div>
-		</td>
-	</tr>
-
-	<tr>
-		<th>
-			<?php $id = Base::O_PURGE_TIMED_URLS_TIME; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-			<?php $this->build_input( $id, null, null, 'time' ); ?>
-			<div class="litespeed-desc">
-				<?php echo sprintf( __( 'Specify the time to purge the "%s" list.', 'litespeed-cache' ), __( 'Scheduled Purge URLs', 'litespeed-cache' ) ); ?>
-				<?php echo sprintf( __( 'Current server time is %s.', 'litespeed-cache' ), '<code>' . date( 'H:i:s', time() + LITESPEED_TIME_OFFSET ) . '</code>' ); ?>
-			</div>
-		</td>
-	</tr>
-
-	<tr>
-		<th>
-			<?php $id = Base::O_PURGE_HOOK_ALL; ?>
-			<?php $this->title( $id ); ?>
-		</th>
-		<td>
-
-			<div class="litespeed-textarea-recommended">
-				<div>
-					<?php $this->build_textarea( $id, 50 ); ?>
+				<div class="litespeed-desc">
+					<?php echo __('Select which pages will be automatically purged when posts are published/updated.', 'litespeed-cache'); ?>
 				</div>
-				<div>
-					<?php $this->recommended( $id ); ?>
+			</td>
+		</tr>
+
+		<tr>
+			<th>
+				<?php $id = Base::O_PURGE_STALE; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_switch($id); ?>
+				<div class="litespeed-desc">
+					<?php echo __('If ON, the stale copy of a cached page will be shown to visitors until a new cache copy is available. Reduces the server load for following visits. If OFF, the page will be dynamically generated while visitors wait.', 'litespeed-cache'); ?>
+					<?php Doc::learn_more('https://docs.litespeedtech.com/lscache/lscwp/cache/#serve-stale'); ?>
 				</div>
-			</div>
+				<div class="litespeed-callout notice notice-warning inline">
+					<h4><?php echo __('Note', 'litespeed-cache'); ?></h4>
+					<p>
+						<?php echo __('By design, this option may serve stale content. Do not enable this option, if that is not OK with you.', 'litespeed-cache'); ?><br />
+					</p>
+				</div>
+			</td>
+		</tr>
 
-			<div class="litespeed-desc">
-				<?php echo __( 'A Purge All will be executed when WordPress runs these hooks.', 'litespeed-cache' ); ?>
-				<?php Doc::learn_more( 'https://docs.litespeedtech.com/lscache/lscwp/cache/#purge-all-hooks' ); ?>
-			</div>
-		</td>
-	</tr>
+		<tr>
+			<th>
+				<?php $id = Base::O_PURGE_TIMED_URLS; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_textarea($id, 80); ?>
+				<div class="litespeed-desc">
+					<?php echo sprintf(__('The URLs here (one per line) will be purged automatically at the time set in the option "%s".', 'litespeed-cache'), __('Scheduled Purge Time', 'litespeed-cache')); ?><br />
+					<?php echo sprintf(__('Both %1$s and %2$s are acceptable.', 'litespeed-cache'), '<code>http://www.example.com/path/url.php</code>', '<code>/path/url.php</code>'); ?>
+					<?php Doc::one_per_line(); ?>
+				</div>
+				<div class="litespeed-desc">
+					<?php echo sprintf(__('Wildcard %1$s supported (match zero or more characters). For example, to match %2$s and %3$s, use %4$s.', 'litespeed-cache'), '<code>*</code>', '<code>/path/u-1.html</code>', '<code>/path/u-2.html</code>', '<code>/path/u-*.html</code>'); ?>
+				</div>
+				<div class="litespeed-callout notice notice-warning inline">
+					<h4><?php echo __('Note', 'litespeed-cache'); ?></h4>
+					<p>
+						<?php echo __('For URLs with wildcards, there may be a delay in initiating scheduled purge.', 'litespeed-cache'); ?><br />
+						<?php Doc::learn_more('https://docs.litespeedtech.com/lscache/lscwp/cache/#scheduled-purge-urls'); ?>
+					</p>
+				</div>
+			</td>
+		</tr>
+
+		<tr>
+			<th>
+				<?php $id = Base::O_PURGE_TIMED_URLS_TIME; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_input($id, null, null, 'time'); ?>
+				<div class="litespeed-desc">
+					<?php echo sprintf(__('Specify the time to purge the "%s" list.', 'litespeed-cache'), __('Scheduled Purge URLs', 'litespeed-cache')); ?>
+					<?php echo sprintf(__('Current server time is %s.', 'litespeed-cache'), '<code>' . date('H:i:s', time() + LITESPEED_TIME_OFFSET) . '</code>'); ?>
+				</div>
+			</td>
+		</tr>
+
+		<tr>
+			<th>
+				<?php $id = Base::O_PURGE_HOOK_ALL; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+
+				<div class="litespeed-textarea-recommended">
+					<div>
+						<?php $this->build_textarea($id, 50); ?>
+					</div>
+					<div>
+						<?php $this->recommended($id); ?>
+					</div>
+				</div>
+
+				<div class="litespeed-desc">
+					<?php echo __('A Purge All will be executed when WordPress runs these hooks.', 'litespeed-cache'); ?>
+					<?php Doc::learn_more('https://docs.litespeedtech.com/lscache/lscwp/cache/#purge-all-hooks'); ?>
+				</div>
+			</td>
+		</tr>
 
 
-</tbody></table>
-
+	</tbody>
+</table>

--- a/tpl/crawler/settings-general.tpl.php
+++ b/tpl/crawler/settings-general.tpl.php
@@ -30,6 +30,25 @@ $this->form_action();
 
 		<tr>
 			<th>
+				<?php $id = Base::O_CRAWLER_SCHEDULE_TIME; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_input($id); ?>
+				<div class="litespeed-desc">
+					<?php echo __('Change the crawler running time.', 'litespeed-cache'); ?>
+					<br />
+					<?php echo __('You can add multiple times delimited by', 'litespeed-cache'); ?> <code>,</code>
+					<br />
+					<?php echo __('Server time:', 'litespeed-cache'); ?> <code><?php echo date('H:m'); ?></code>
+					<br />
+					<code>00:00-06:00,20:00-23:59</code>
+				</div>
+			</td>
+		</tr>
+
+		<tr>
+			<th>
 				<?php $id = Base::O_CRAWLER_USLEEP; ?>
 				<?php $this->title($id); ?>
 			</th>

--- a/tpl/page_optm/settings_html.tpl.php
+++ b/tpl/page_optm/settings_html.tpl.php
@@ -89,6 +89,26 @@ defined('WPINC') || exit;
 
 		<tr>
 			<th>
+				<?php $id = Base::O_OPTM_HTML_SKIP_COMMENTS; ?>
+				<?php $this->title($id); ?>
+			</th>
+			<td>
+				<?php $this->build_textarea($id); ?>
+				<div class="litespeed-desc">
+					<?php echo __('Keep html comments.', 'litespeed-cache'); ?>
+					<br />
+					<?php echo __('If comment to be kept is like:', 'litespeed-cache'); ?>
+					<code>&lt;!-- A comment that need to be here --&gt;</code>
+					<?php echo __('write:', 'litespeed-cache'); ?>
+					<code>A comment that need to be here</code>
+					<br />
+					<?php Doc::one_per_line(); ?>
+				</div>
+			</td>
+		</tr>
+
+		<tr>
+			<th>
 				<?php $id = Base::O_OPTM_QS_RM; ?>
 				<?php $this->title($id); ?>
 			</th>


### PR DESCRIPTION
- Added an option to make LSCWP's cache crawler feature run within a certain range of time only
- Added an option to whitelist certain HTML comments from being minified; this is needed for some plugins, as suggested here: https://wordpress.org/support/topic/feature-request-option-to-disable-removing-comments-when-minifing-html/
- Added an option to keep guest mode pages and only purge normal pages when using LSCWP's "Purge All" function.