### PR TITLE
Release lane when crawler position is reset

### DIFF
--- a/src/crawler.cls.php
+++ b/src/crawler.cls.php
@@ -1229,6 +1229,8 @@ class Crawler extends Root
 	{
 		File::save($this->_resetfile, time(), true);
 
+		$this->Release_lane();
+
 		self::save_summary(array('is_running' => 0));
 	}
 


### PR DESCRIPTION
This should allow the "Manually run" button to work every time as expected.