### PR TITLE
Fix for ticket #485348 - LSCWP: ESI not working in the Block Editor

### DIFF
--- a/src/core.cls.php
+++ b/src/core.cls.php
@@ -540,17 +540,19 @@ class Core extends Root
 		$buffer = apply_filters('litespeed_buffer_after', $buffer);
 		
 		// Make sure ESI links are decoded in situation where links are changed by block editor, in render function with wptexturize. Ticket #485348.
-		if(preg_match_all('/(<esi.*src=["\'])(.*)(["\'].*\/>)/mU', $buffer, $matchesEsi)){
+		if(preg_match_all('/(<esi.+src=["\'])(.*)(["\'].*\/>)/mU', $buffer, $matchesEsi)){
 			foreach($matchesEsi[2] as $index => $match){
 				$data = $match;
 				// entity decode needs changes. For example: if finds &#038;
-				if(preg_match('/&#(.*);/mU', $data) === 1){
+				if(preg_match('/&#(.+);/mU', $data) === 1){
 					$data = html_entity_decode($data);
 					$data = rawurldecode($data);
 				}
 				
 				if($data !== $match){
-					$buffer = str_replace($matchesEsi[1][$index].$match.$matchesEsi[3][$index], $matchesEsi[1][$index].$data.$matchesEsi[3][$index], $buffer);
+					$pre_url = $matchesEsi[1][$index];
+					$post_url = $matchesEsi[3][$index];
+					$buffer = str_replace($pre_url.$match.$post_url, $pre_url.$data.$post_url, $buffer);
 				}
 			}
 		}

--- a/src/core.cls.php
+++ b/src/core.cls.php
@@ -538,6 +538,22 @@ class Core extends Root
 
 		// Hook to modify buffer after
 		$buffer = apply_filters('litespeed_buffer_after', $buffer);
+		
+		// Make sure ESI links are decoded in situation where links are changed by block editor, in render function with wptexturize. Ticket #485348.
+		if(preg_match_all('/(<esi.*src=["\'])(.*)(["\'].*\/>)/mU', $buffer, $matchesEsi)){
+			foreach($matchesEsi[2] as $index => $match){
+				$data = $match;
+				// entity decode needs changes. For example: if finds &#038;
+				if(preg_match('/&#(.*);/mU', $data) === 1){
+					$data = html_entity_decode($data);
+					$data = rawurldecode($data);
+				}
+				
+				if($data !== $match){
+					$buffer = str_replace($matchesEsi[1][$index].$match.$matchesEsi[3][$index], $matchesEsi[1][$index].$data.$matchesEsi[3][$index], $buffer);
+				}
+			}
+		}
 
 		Debug2::ended();
 


### PR DESCRIPTION
Make sure ESI links are decoded in situation where links are changed by block editor, in render function with wptexturize.