### PR TITLE
Remove WooCommerce Geolocation Redirect on ESI

### DIFF
--- a/thirdparty/woocommerce.cls.php
+++ b/thirdparty/woocommerce.cls.php
@@ -103,6 +103,13 @@ class WooCommerce extends Base
 				return array_unique($list);
 			});
 		}
+
+		// #612331 - remove Woocommerce geolocation redirect on ESI page
+		$link_action = $this->cls('ESI')::QS_ACTION;
+		$link_param = $this->cls('ESI')::QS_PARAMS;
+		if (!empty($_GET[$link_action]) && !empty($_GET[$link_param])) {
+            remove_action( 'template_redirect', array( 'WC_Cache_Helper', 'geolocation_ajax_redirect' ), 10 );
+		}
 	}
 
 	/**

--- a/thirdparty/woocommerce.cls.php
+++ b/thirdparty/woocommerce.cls.php
@@ -105,8 +105,9 @@ class WooCommerce extends Base
 		}
 
 		// #612331 - remove Woocommerce geolocation redirect on ESI page
-		$link_action = $this->cls('ESI')::QS_ACTION;
-		$link_param = $this->cls('ESI')::QS_PARAMS;
+		$class_esi = $this->cls('ESI');
+		$link_action = $class_esi->QS_ACTION;
+		$link_param = $class_esi->QS_PARAMS;
 		if (!empty($_GET[$link_action]) && !empty($_GET[$link_param])) {
             remove_action( 'template_redirect', array( 'WC_Cache_Helper', 'geolocation_ajax_redirect' ), 10 );
 		}


### PR DESCRIPTION
When WooCoommerce Geolocation is active we need to remove the redirection to **?v** query string