### PR TITLE
PHP 5.3 - fix error in cloud ip verification

### DIFF
--- a/src/cloud.cls.php
+++ b/src/cloud.cls.php
@@ -1155,7 +1155,8 @@ class Cloud extends Base
 			return self::err('lack_of_param');
 		}
 
-		if (empty($this->_api_key())) {
+		// Note: Using empty here throws a fatal error in PHP v5.3
+		if (!$this->_api_key()) {
 			self::debug('Lack of API key');
 			return self::err('lack_of_api_key');
 		}


### PR DESCRIPTION
Error occurred when activating the plugin on PHP 5.3

Fix found by reading: https://stackoverflow.com/questions/1075534/cant-use-method-return-value-in-write-context