### PR TITLE
Add fix to disable UCSS exclusion when UCSS not active

### DIFF
--- a/src/optimize.cls.php
+++ b/src/optimize.cls.php
@@ -1089,7 +1089,7 @@ class Optimize extends Base
 				}
 
 				// Check if need to inline this css file
-				if (Utility::str_hit_array($attrs['href'], $ucss_file_exc_inline)) {
+				if ($this->conf(self::O_OPTM_UCSS) && Utility::str_hit_array($attrs['href'], $ucss_file_exc_inline)) {
 					Debug2::debug('[Optm] ucss_file_exc_inline hit ' . $attrs['href']);
 					// Replace this css to inline from orig html
 					$inline_script = '<style>' . $this->__optimizer->load_file($attrs['href']) . '</style>';


### PR DESCRIPTION
Fix for https://trello.com/c/NSHQCOij/121-disable-ucss-exclusions-when-ucss-is-not-functional-on-the-page