### PR TITLE
Keep image attributes when replacing dimensions

### DIFF
--- a/src/media.cls.php
+++ b/src/media.cls.php
@@ -758,7 +758,7 @@ class Media extends Root
 
 						$attrs['width'] = $ori_width;
 						$attrs['height'] = $ori_height;
-						$new_html = preg_replace('#\s+(width|height)=(["\'])[^\2]*\2#', '', $match[0]);
+						$new_html = preg_replace('#\s+(width|height)=(["\'])[^\2]*\2(["\'])#', '', $match[0]);
 						$new_html = preg_replace('#<img\s+#i', '<img width="' . $attrs['width'] . '" height="' . $attrs['height'] . '" ', $new_html);
 						self::debug('Add missing sizes ' . $attrs['width'] . 'x' . $attrs['height'] . ' to ' . $attrs['src']);
 						$this->content = str_replace($match[0], $new_html, $this->content);

--- a/src/media.cls.php
+++ b/src/media.cls.php
@@ -758,7 +758,7 @@ class Media extends Root
 
 						$attrs['width'] = $ori_width;
 						$attrs['height'] = $ori_height;
-						$new_html = preg_replace('#\s+(width|height)=(["\'])[^\2]*\2(["\'])#', '', $match[0]);
+						$new_html = preg_replace('#\s+(width|height)=(["\'])[^\2]*?\2#', '', $match[0]);
 						$new_html = preg_replace('#<img\s+#i', '<img width="' . $attrs['width'] . '" height="' . $attrs['height'] . '" ', $new_html);
 						self::debug('Add missing sizes ' . $attrs['width'] . 'x' . $attrs['height'] . ' to ' . $attrs['src']);
 						$this->content = str_replace($match[0], $new_html, $this->content);


### PR DESCRIPTION
Ticket: #381779 - LSCWP: Lazy loaded Image elements do not have [alt] attributes
@qtwrk shared the bug