### PR TITLE
Update headers in litespeed-cache.php

### DIFF
--- a/litespeed-cache.php
+++ b/litespeed-cache.php
@@ -7,7 +7,6 @@
  * Version:           6.4-a8
  * Requires PHP:      7.2
  * Requires at least: 5.3
- * Tested up to:      6.6
  * Author:            LiteSpeed Technologies
  * Author URI:        https://www.litespeedtech.com
  * License:           GPLv3

--- a/litespeed-cache.php
+++ b/litespeed-cache.php
@@ -5,6 +5,9 @@
  * Plugin URI:        https://www.litespeedtech.com/products/cache-plugins/wordpress-acceleration
  * Description:       High-performance page caching and site optimization from LiteSpeed
  * Version:           6.4-a8
+ * Requires PHP:      7.2
+ * Requires at least: 5.3
+ * Tested up to:      6.6
  * Author:            LiteSpeed Technologies
  * Author URI:        https://www.litespeedtech.com
  * License:           GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: LiteSpeedTech
 Tags: caching, optimize, performance, pagespeed, core web vitals, seo, speed, image optimize, compress, object cache, redis, memcached, database cleaner
 Requires at least: 5.3
-Tested up to: 6.6.1
+Tested up to: 6.6
 Stable tag: 6.3.0.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html

--- a/src/esi.cls.php
+++ b/src/esi.cls.php
@@ -770,10 +770,10 @@ class ESI extends Root
 	{
 		global $wp_admin_bar;
 
-		if ( $this->admin_rendered ) {
+		if ($this->admin_rendered) {
 			return;
 		}
-	
+
 		if (!is_admin_bar_showing() || !is_object($wp_admin_bar)) {
 			return;
 		}


### PR DESCRIPTION
> Since WordPress 5.8 plugin readme files are not parsed for requirements.

> Tested up to: This field ignores minor versions, as plugins shouldn’t break with a minor update.

https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/
