### PR TITLE
Correct the integration with User Switching

### DIFF
--- a/thirdparty/user-switching.cls.php
+++ b/thirdparty/user-switching.cls.php
@@ -12,7 +12,7 @@ class User_Switching
 {
 	public static function detect()
 	{
-		if (!defined('user_switching')) {
+		if (!class_exists('user_switching')) {
 			return;
 		}
 


### PR DESCRIPTION
I'm not exactly sure what this integration does but I noticed that it checks for a constant named `user_switching` instead of a class of that name, which means the integration will never be triggered.

This change corrects the guard condition.