### PR TITLE
OC debug improve

### DIFF
--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -29,6 +29,7 @@ class Object_Cache extends Root
 	const O_OBJECT_GLOBAL_GROUPS = 'object-global_groups';
 	const O_OBJECT_NON_PERSISTENT_GROUPS = 'object-non_persistent_groups';
 
+	private $debug;
 	private $_conn;
 	private $_cfg_debug;
 	private $_cfg_enabled;
@@ -58,9 +59,6 @@ class Object_Cache extends Root
 	 */
 	public function __construct($cfg = false)
 	{
-		$this->debug_oc('-------------');
-		$this->debug_oc('init');
-
 		if ($cfg) {
 			if (!is_array($cfg[Base::O_OBJECT_GLOBAL_GROUPS])) {
 				$cfg[Base::O_OBJECT_GLOBAL_GROUPS] = explode("\n", $cfg[Base::O_OBJECT_GLOBAL_GROUPS]);
@@ -138,6 +136,8 @@ class Object_Cache extends Root
 		} else {
 			$this->_cfg_enabled = false;
 		}
+
+		$this->init_debug();
 	}
 
 	/**
@@ -148,6 +148,21 @@ class Object_Cache extends Root
 	 */
 	private function debug_oc($text)
 	{
+		if (!$this->_cfg_debug || null === $this->debug) {
+			return;
+		}
+
+		error_log(gmdate('m/d/y H:i:s') . ' - OC - ' . $text . PHP_EOL, 3, $this->debug->path('debug'));
+	}
+
+	/**
+	 * Init debug.
+	 *
+	 * @since  6.5
+	 * @access private
+	 */
+	private function init_debug()
+	{
 		if (!$this->_cfg_debug) {
 			return;
 		}
@@ -155,9 +170,7 @@ class Object_Cache extends Root
 		// For initiate Debug2 class
 		!defined('LITESPEED_DATA_FOLDER') && define('LITESPEED_DATA_FOLDER', 'litespeed');
 		!defined('LITESPEED_STATIC_DIR') && define('LITESPEED_STATIC_DIR', WP_CONTENT_DIR . '/'. LITESPEED_DATA_FOLDER);
-		$debug2 = new Debug2();
-
-		error_log(gmdate('m/d/y H:i:s') . ' - OC - ' . $text . PHP_EOL, 3, $debug2->path('debug'));
+		$this->debug = new Debug2();
 	}
 
 	/**
@@ -286,7 +299,7 @@ class Object_Cache extends Root
 			return false;
 		}
 
-		$this->debug_oc('Init ' . $this->_oc_driver . ' connection to ' . $this->_cfg_host . ':' . $this->_cfg_port);
+		$this->debug_oc('Initializing ' . $this->_oc_driver . ' connection to ' . $this->_cfg_host . ':' . $this->_cfg_port);
 
 		$failed = false;
 		/**

--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -146,9 +146,9 @@ class Object_Cache extends Root
 	 * @since  6.3
 	 * @access private
 	 */
-	private function debug_oc($text, $show_error = false)
+	private function debug_oc($text)
 	{
-		if (!$show_error && !$this->_cfg_debug) {
+		if (!$this->_cfg_debug) {
 			return;
 		}
 
@@ -286,8 +286,7 @@ class Object_Cache extends Root
 			return false;
 		}
 
-		$this->debug_oc('Init ' . $this->_oc_driver . ' connection');
-		$this->debug_oc('connecting to ' . $this->_cfg_host . ':' . $this->_cfg_port);
+		$this->debug_oc('Init ' . $this->_oc_driver . ' connection to ' . $this->_cfg_host . ':' . $this->_cfg_port);
 
 		$failed = false;
 		/**
@@ -334,10 +333,10 @@ class Object_Cache extends Root
 					$failed = true;
 				}
 			} catch (\Exception $e) {
-				$this->debug_oc('Redis connect exception: ' . $e->getMessage(), true);
+				$this->debug_oc('Redis connect exception: ' . $e->getMessage());
 				$failed = true;
 			} catch (\ErrorException $e) {
-				$this->debug_oc('Redis connect error: ' . $e->getMessage(), true);
+				$this->debug_oc('Redis connect error: ' . $e->getMessage());
 				$failed = true;
 			}
 			restore_error_handler();
@@ -381,7 +380,7 @@ class Object_Cache extends Root
 
 		// If failed to connect
 		if ($failed) {
-			$this->debug_oc('❌ Failed to connect ' . $this->_oc_driver . ' server!', true);
+			$this->debug_oc('❌ Failed to connect ' . $this->_oc_driver . ' server!');
 			$this->_conn = null;
 			$this->_cfg_enabled = false;
 			!defined('LITESPEED_OC_FAILURE') && define('LITESPEED_OC_FAILURE', true);
@@ -389,7 +388,7 @@ class Object_Cache extends Root
 			return false;
 		}
 
-		$this->debug_oc('Connected');
+		$this->debug_oc('✅ Connected to ' . $this->_oc_driver .' server.' );
 
 		return true;
 	}

--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -152,13 +152,12 @@ class Object_Cache extends Root
 			return;
 		}
 
-		if (defined('LSCWP_LOG')) {
-			Debug2::debug($text);
+		// For initiate Debug2 class
+		!defined('LITESPEED_DATA_FOLDER') && define('LITESPEED_DATA_FOLDER', 'litespeed');
+		!defined('LITESPEED_STATIC_DIR') && define('LITESPEED_STATIC_DIR', WP_CONTENT_DIR . '/'. LITESPEED_DATA_FOLDER);
+		$debug2 = new Debug2();
 
-			return;
-		}
-
-		error_log(gmdate('m/d/y H:i:s') . ' - ' . $text . PHP_EOL, 3, WP_CONTENT_DIR . '/debug.log');
+		error_log(gmdate('m/d/y H:i:s') . ' - OC - ' . $text . PHP_EOL, 3, $debug2->path('debug'));
 	}
 
 	/**

--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -168,8 +168,7 @@ class Object_Cache extends Root
 		}
 
 		// For initiate Debug2 class
-		!defined('LITESPEED_DATA_FOLDER') && define('LITESPEED_DATA_FOLDER', 'litespeed');
-		!defined('LITESPEED_STATIC_DIR') && define('LITESPEED_STATIC_DIR', WP_CONTENT_DIR . '/'. LITESPEED_DATA_FOLDER);
+		!defined('LITESPEED_STATIC_DIR') && define('LITESPEED_STATIC_DIR', WP_CONTENT_DIR . '/litespeed');
 		$this->debug = new Debug2();
 	}
 

--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -148,13 +148,13 @@ class Object_Cache extends Root
 	 */
 	private function debug_oc($text, $show_error = false)
 	{
-		if (defined('LSCWP_LOG')) {
-			Debug2::debug($text);
-
+		if (!$show_error && !$this->_cfg_debug) {
 			return;
 		}
 
-		if (!$show_error && !$this->_cfg_debug) {
+		if (defined('LSCWP_LOG')) {
+			Debug2::debug($text);
+
 			return;
 		}
 


### PR DESCRIPTION
After Log folder change, OC was debugging to WP default log file.
With these changes OC will follow default path writting to "debug" log AND will not show connection error if debug is OFF
I did some text improvements