### PR TITLE
Rely on just-in-time translation loading

### DIFF
--- a/src/core.cls.php
+++ b/src/core.cls.php
@@ -81,8 +81,6 @@ class Core extends Root
 		register_uninstall_hook($plugin_file, __NAMESPACE__ . '\Activation::uninstall_litespeed_cache');
 		// }
 
-		add_action('plugins_loaded', array($this, 'plugins_loaded'));
-
 		if (defined('LITESPEED_ON')) {
 			// register purge_all actions
 			$purge_all_events = $this->conf(Base::O_PURGE_HOOK_ALL);
@@ -154,15 +152,6 @@ class Core extends Root
 			Debug2::debug('[ESI] Overwrite wp_create_nonce()');
 			litespeed_define_nonce_func();
 		}
-	}
-
-	/**
-	 * Plugin loaded hooks
-	 * @since 3.0
-	 */
-	public function plugins_loaded()
-	{
-		load_plugin_textdomain(Core::PLUGIN_NAME, false, 'litespeed-cache/lang/');
 	}
 
 	/**


### PR DESCRIPTION
The plugin was loading translations too early on `plugins_loaded`. Plugins should wait until `init` to ensure the current user has been set up, so that the current user's locale can be respected.

That said, why manually load translations when WordPress can do it for you :-)

Removes the manual `load_plugin_textdomain()` call to rely on WordPress to load translations at the right time, which was added in WordPress 4.6.