### PR TITLE
Remove deprecated notice

### DIFF
--- a/src/cdn.cls.php
+++ b/src/cdn.cls.php
@@ -312,7 +312,9 @@ class CDN extends Root
 
 			// Parse file postfix
 			$parsed_url = parse_url($url, PHP_URL_PATH);
-			if(is_null($parsed_url)) continue;
+			if (!$parsed_url) {
+				continue;
+			}
 
 			$postfix = '.' . pathinfo($parsed_url, PATHINFO_EXTENSION);
 			if (array_key_exists($postfix, $this->_cfg_cdn_mapping)) {

--- a/src/cdn.cls.php
+++ b/src/cdn.cls.php
@@ -311,7 +311,10 @@ class CDN extends Root
 			$url = str_replace(array(' ', '\t', '\n', '\r', '\0', '\x0B', '"', "'", '&quot;', '&#039;'), '', $url);
 
 			// Parse file postfix
-			$postfix = '.' . pathinfo(parse_url($url, PHP_URL_PATH), PATHINFO_EXTENSION);
+			$parsed_url = parse_url($url, PHP_URL_PATH);
+			if(is_null($parsed_url)) continue;
+
+			$postfix = '.' . pathinfo($parsed_url, PATHINFO_EXTENSION);
 			if (array_key_exists($postfix, $this->_cfg_cdn_mapping)) {
 				Debug2::debug2('[CDN] matched file_type ' . $postfix . ' : ' . $url);
 				if (!($url2 = $this->rewrite($url, Base::CDN_MAPPING_FILETYPE, $postfix))) {


### PR DESCRIPTION
Removing deprecated notice from this thread: https://wordpress.org/support/topic/php-deprecated-notice-14/

The fix is made to catch a case where the url cannot be parsed and returning null.