### PR TITLE
Fix

### DIFF
--- a/src/base.cls.php
+++ b/src/base.cls.php
@@ -560,6 +560,7 @@ class Base extends Root
 		self::O_CACHE_BROWSER => false,
 		self::O_CACHE_MOBILE => false,
 		self::O_CACHE_MOBILE_RULES => array(),
+		self::O_CACHE_DROP_QS => array(),
 		self::O_CACHE_LOGIN_COOKIE => '',
 		self::O_CACHE_VARY_COOKIES => array(),
 		self::O_CACHE_EXC_COOKIES => array(),


### PR DESCRIPTION
Fix error on save: https://wordpress.org/support/topic/drop-query-string-setting-is-not-saved-on-multisite-install