### PR TITLE
Update Optimize class to follow site permalink

### DIFF
--- a/src/optimize.cls.php
+++ b/src/optimize.cls.php
@@ -274,7 +274,11 @@ class Optimize extends Base
 	private function _optimize()
 	{
 		global $wp;
-		$this->_request_url = home_url($wp->request);
+		$this->_request_url = get_permalink();
+		// Backup, in case get_permalink() fails.
+		if (!$this->_request_url) {
+			$this->_request_url = home_url($wp->request);
+		}
 
 		$this->cfg_css_min = defined('LITESPEED_GUEST_OPTM') || $this->conf(self::O_OPTM_CSS_MIN);
 		$this->cfg_css_comb = defined('LITESPEED_GUEST_OPTM') || $this->conf(self::O_OPTM_CSS_COMB);


### PR DESCRIPTION
Test case:
Create a WP site
Change permalink to: `/index.php/%year%/%monthnum%/%day%/%postname%/`
Enable UCSS in LSC
Clear all cache(UCSS too)
Visit a page that will generate UCSS
Come back to list of link to be generated, it will be without `index.php` in link

Ticket:  https://wordpress.org/support/topic/wordpress-plugin-does-not-seem-to-follow-right-permalink-structure/