### PR TITLE
Fix PHP 7.2 compatibility

### DIFF
--- a/src/cloud.cls.php
+++ b/src/cloud.cls.php
@@ -224,7 +224,7 @@ class Cloud extends Base
 			$msg = sprintf(
 				__('You need to set the %1$s first. Please use the command %2$s to set.', 'litespeed-cache'),
 				'`' . __('Server IP', 'litespeed-cache') . '`',
-				'`wp litespeed-option set server_ip __your_ip_value__`',
+				'`wp litespeed-option set server_ip __your_ip_value__`'
 			);
 			Admin_Display::error($msg);
 			return;
@@ -279,7 +279,7 @@ class Cloud extends Base
 			$msg = sprintf(
 				__('You need to set the %1$s first. Please use the command %2$s to set.', 'litespeed-cache'),
 				'`' . __('Server IP', 'litespeed-cache') . '`',
-				'`wp litespeed-option set server_ip __your_ip_value__`',
+				'`wp litespeed-option set server_ip __your_ip_value__`'
 			);
 			Admin_Display::error($msg);
 			return;


### PR DESCRIPTION
Remove trailing commas.

Please see https://github.com/litespeedtech/lscache_wp/actions/runs/11709688197/job/32614265284

This goes into `dev`, `master` also needs a fix.