### PR TITLE
Fix

### DIFF
--- a/src/crawler.cls.php
+++ b/src/crawler.cls.php
@@ -1210,9 +1210,9 @@ class Crawler extends Root
 	 */
 	public function json_local_path()
 	{
-		if (!file_exists(LITESPEED_STATIC_DIR . '/crawler/' . $this->_sitemeta)) {
-			return false;
-		}
+		// if (!file_exists(LITESPEED_STATIC_DIR . '/crawler/' . $this->_sitemeta)) {
+		// 	return false;
+		// }
 
 		return LITESPEED_STATIC_DIR . '/crawler/' . $this->_sitemeta;
 	}


### PR DESCRIPTION
Fix error reported on: https://wordpress.org/support/topic/unknown-file-in-wordpress-core-wp-admin-pid-what-is-this-file/

I was able to reproduce the error:
- activate crawler and sitemap
- go on ftp and delete **wp-content/litespeed/crawler**
- go in admin
- run crawler
- a .pid file will appear in **wp-admin** folder

From what I see the function should return a string always.
I looked over the code where other instances of function is used and all is used as string and 1 place where file is checked if exists before.