### PR TITLE
Fix php notice

### DIFF
--- a/src/cloud.cls.php
+++ b/src/cloud.cls.php
@@ -1662,6 +1662,8 @@ class Cloud extends Base
 		// Auto delete if too long ago
 		if (time() - $this->_summary['err_domains'][$home_url] > 86400 * 10) {
 			$this->_remove_domain_from_err_list($home_url);
+
+			return false;
 		}
 		if (time() - $this->_summary['err_domains'][$home_url] > 86400) {
 			return false;


### PR DESCRIPTION
Report: https://wordpress.org/support/topic/php-warning-511

If the domain is present in this if, it test in the next condition and will show a warning.
If too long this means the error is no longer available