### PR TITLE
CDN - remove filetypes to replace if setting is disabled

### DIFF
--- a/src/admin-settings.cls.php
+++ b/src/admin-settings.cls.php
@@ -117,6 +117,35 @@ class Admin_Settings extends Base
 						foreach ($data as $k => $v) {
 							if ($child == self::CDN_MAPPING_FILETYPE) {
 								$v = Utility::sanitize_lines($v);
+
+								// Remove from MAPPING FILETYPE IMAGES/CSS/JS if settings are disabled
+								$remove_type = array();
+								if (empty($data2[$k][self::CDN_MAPPING_INC_IMG])) {
+									$remove_type = array_merge($remove_type, array('jpg', 'jpeg', 'png', 'gif', 'svg', 'webp', 'avif'));
+								}
+								if (empty($data2[$k][self::CDN_MAPPING_INC_CSS])) {
+									$remove_type[] = 'css';
+								}
+								if (empty($data2[$k][self::CDN_MAPPING_INC_JS])) {
+									$remove_type[] = 'js';
+								}
+
+								if (count($remove_type) > 0) {
+									$temp = array_filter($v, function ($i_v) use ($remove_type) {
+										$leave_value = true;
+
+										foreach ($remove_type as $remove) {
+											if (strpos($i_v, $remove) !== false) {
+												$leave_value = false;
+												break;
+											}
+										}
+
+										return $leave_value;
+									});
+
+									$v = array_values($temp);
+								}
 							}
 							if ($child == self::CDN_MAPPING_URL) {
 								# If not a valid URL, turn off CDN


### PR DESCRIPTION
In CDN, at mapping settings if Include Images/CSS/JS is disabled it removes the file types from "Include File Types" setting.
Before:
![image](https://github.com/user-attachments/assets/174edbb2-a3c8-47f9-8038-cd4adb0e0ef7)
After save:
![image](https://github.com/user-attachments/assets/98dcc5c1-57f6-4b03-b033-9a2a5254a07e)
