### PR TITLE
Add Cookie path check

### DIFF
--- a/src/vary.cls.php
+++ b/src/vary.cls.php
@@ -731,6 +731,19 @@ class Vary extends Root
 		return false;
 	}
 
+	private function test_cookie_path($path)
+	{
+		if ($path[0] != '/') {
+			return false;
+		}
+
+		if (preg_match('/[\x00-\x1F\x7F]/', $path)) {
+			return false;
+		}
+
+		return true;
+	}
+
 	/**
 	 * Set the vary cookie.
 	 *
@@ -744,6 +757,11 @@ class Vary extends Root
 	 */
 	private function _cookie($val = false, $expire = false, $path = false)
 	{
+		if (!$this->test_cookie_path($path)) {
+			Debug2::debug('[Vary] Cannot set cookie: ' . self::$_vary_name . '. Incorrect path: ' . $path);
+			return;
+		}
+
 		if (!$val) {
 			$expire = 1;
 		}


### PR DESCRIPTION
Based on this report https://wordpress.org/support/topic/fatal-error-in-litespeed-cache-setcookie-path-issue/
Added the code change from this PR.