### PR TITLE
WP Consent API

### DIFF
--- a/src/lang.cls.php
+++ b/src/lang.cls.php
@@ -46,12 +46,12 @@ class Lang extends Base
 	{
 		$map = array(
 			'auto_alias_failed_cdn' =>
-			__('Unable to automatically add %1$s as a Domain Alias for main %2$s domain, due to potential CDN conflict.', 'litespeed-cache') .
+				__('Unable to automatically add %1$s as a Domain Alias for main %2$s domain, due to potential CDN conflict.', 'litespeed-cache') .
 				' ' .
 				Doc::learn_more('https://quic.cloud/docs/cdn/dns/how-to-setup-domain-alias/', false, false, false, true),
 
 			'auto_alias_failed_uid' =>
-			__('Unable to automatically add %1$s as a Domain Alias for main %2$s domain.', 'litespeed-cache') .
+				__('Unable to automatically add %1$s as a Domain Alias for main %2$s domain.', 'litespeed-cache') .
 				' ' .
 				__('Alias is in use by another QUIC.cloud account.', 'litespeed-cache') .
 				' ' .

--- a/thirdparty/entry.inc.php
+++ b/thirdparty/entry.inc.php
@@ -37,6 +37,7 @@ $third_cls = array(
 	'WPML',
 	'WpTouch',
 	'Yith_Wishlist',
+	'WP_Consent_API',
 );
 
 foreach ($third_cls as $cls) {

--- a/thirdparty/wp-consent-api.cls.php
+++ b/thirdparty/wp-consent-api.cls.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * The Third Party integration with WP Consent API.
+ *
+ *
+ * @since		7.0.0
+ */
+namespace LiteSpeed\Thirdparty;
+
+defined('WPINC') || exit();
+
+class WP_Consent_API
+{
+	public static function detect()
+	{
+		if (!class_exists('WP_CONSENT_API')) {
+			return;
+		}
+
+		// Remove LSC warning about consent that appear in Site Health API.
+		// Topic: https://wordpress.org/support/topic/consent-api/
+		// Talk with plugin author: https://wordpress.org/support/topic/litespeed-cache-26
+		$plugin = plugin_basename(LSCWP_BASENAME);
+		add_filter("wp_consent_api_registered_$plugin", '__return_true');
+	}
+}


### PR DESCRIPTION
Remove LSC warning from site health about Consent API. WP Consent API was adding a warning about LSC: **One or more plugins are not conforming to the Consent API.**

Topic: https://wordpress.org/support/topic/consent-api/
Talk with plugin author: https://wordpress.org/support/topic/litespeed-cache-26


This PR:
- will remove the warning
- fix a formatting issue