### PR TITLE
Multisite - Fix activation bug when no plugins active

### DIFF
--- a/src/activation.cls.php
+++ b/src/activation.cls.php
@@ -163,7 +163,7 @@ class Activation extends Base
 		foreach ($sites as $site) {
 			$bid = is_object($site) && property_exists($site, 'blog_id') ? $site->blog_id : $site;
 			$plugins = get_blog_option($bid, 'active_plugins', $default);
-			if (in_array(LSCWP_BASENAME, $plugins, true)) {
+			if (!empty($plugins) && in_array(LSCWP_BASENAME, $plugins, true)) {
 				$count++;
 			}
 		}


### PR DESCRIPTION
When activating LSC on a multisite and one of the sites has no plugins active, it will throw fatal error.
This PR will fix the error.

Details: ticket #9496550 