### PR TITLE
OPcache - handle opcache.restrict_api setting

### DIFF
--- a/src/purge.cls.php
+++ b/src/purge.cls.php
@@ -398,11 +398,34 @@ class Purge extends Base
 	public function purge_all_opcache($silence = false)
 	{
 		if (!Router::opcache_enabled()) {
-			self::debug('Failed to reset opcode cache due to opcache not enabled');
+			self::debug('❌ Failed to reset opcode cache due to opcache not enabled');
 
 			if (!$silence) {
 				$msg = __('Opcode cache is not enabled.', 'litespeed-cache');
-				Admin_Display::error($msg);
+				!defined('LITESPEED_PURGE_SILENT') && Admin_Display::error($msg);
+			}
+
+			return false;
+		}
+
+		if (Router::opcache_restricted(__FILE__)) {
+			self::debug('❌ Failed to reset opcode cache due to OPcache is restricted. File requesting the clear is not allowed.');
+
+			if (!$silence) {
+				$msg = __('OPcache is restricted by "restrict_api".', 'litespeed-cache');
+				!defined('LITESPEED_PURGE_SILENT') && Admin_Display::error($msg);
+			}
+
+			return false;
+		}
+
+		// Purge opcode cache
+		if (!opcache_reset()) {
+			self::debug('❌ Reset opcode not worked');
+
+			if (!$silence) {
+				$msg = __('Reset the opcode cache was not successfully.', 'litespeed-cache');
+				!defined('LITESPEED_PURGE_SILENT') && Admin_Display::success($msg);
 			}
 
 			return false;
@@ -411,8 +434,6 @@ class Purge extends Base
 		// Action to run after opcache purge.
 		do_action('litespeed_purged_all_opcache');
 
-		// Purge opcode cache
-		opcache_reset();
 		self::debug('Reset opcode cache');
 
 		if (!$silence) {

--- a/src/router.cls.php
+++ b/src/router.cls.php
@@ -754,6 +754,28 @@ class Router extends Base
 	}
 
 	/**
+	 * Check if opcode cache is restricted and file that is requesting.
+	 * https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.restrict-api
+	 *
+	 * @since  7.0
+	 * @access public
+	 */
+	public static function opcache_restricted($file)
+	{
+		$restrict_value = ini_get('opcache.restrict_api');
+		if ($restrict_value) {
+			if ($file) {
+				// if file if not in path, it will show warning.
+				return strpos($file, $restrict_value) === false;
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Handle static files
 	 *
 	 * @since  3.0


### PR DESCRIPTION
When opcache parameter **restrict_api** is set there is a warning when OPCache is cleared.
Reading: [https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.restrict-api](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.restrict-api) I see that it also blocks the request.

Fix: if **restrict_api** is not set or empty, reset cache will work.
If path from **restrict_api** is found in script that starts the reset, it will work.
Eg: **opcache.restrict_api="/home/ssssss.com/public_html"** 

Tickets:
https://wordpress.org/support/topic/zend-opcache-api-is-restricted-by-restrict_api-5/
#9496550