### PR TITLE
Fix error message in admin

### DIFF
--- a/src/htaccess.cls.php
+++ b/src/htaccess.cls.php
@@ -365,9 +365,9 @@ class Htaccess extends Root
 
 		$rule_cookie = substr($rule, strlen('RewriteRule .? - [E='), -1);
 
-		if (LITESPEED_SERVER_TYPE === 'LITESPEED_SERVER_OLS') {
-			$rule_cookie = trim($rule_cookie, '"');
-		}
+		//if (LITESPEED_SERVER_TYPE === 'LITESPEED_SERVER_OLS') {
+		$rule_cookie = trim($rule_cookie, '"');
+		//}
 
 		// Drop `Cache-Vary:`
 		$rule_cookie = substr($rule_cookie, strlen('Cache-Vary:'));


### PR DESCRIPTION
I checked on Enterprise server and Htaccess::current_login_cookie() returns a string starting with **:**  and ending with **"**

Ticket: #4003352 from QC tickets.