### PR TITLE
Remove errors when open_basedir restriction is on

### DIFF
--- a/lib/css_js_min/minify/minify.cls.php
+++ b/lib/css_js_min/minify/minify.cls.php
@@ -458,6 +458,43 @@ abstract class Minify
     }
 
     /**
+     * Check if the input is a file path.
+     *
+     * @param string $path
+     *
+     * @return bool
+     */
+    protected function detectUrlType(string $input) {
+        // Is CSS
+        if (strpos($input, '{') !== false && strpos($input, '}') !== false && strpos($input, ';') !== false) {
+            return false;
+        }
+
+        // Is JS
+        if (strpos($input, 'function') !== false ||
+            strpos($input, 'var ') !== false ||
+            strpos($input, 'let ') !== false ||
+            strpos($input, 'const ') !== false ||
+            strpos($input, '=>') !== false ||
+            strpos($input, ';') !== false ||
+            strpos($input, '(') !== false && strpos($input, ')') !== false ||
+            strpos($input, '{') !== false && strpos($input, '}') !== false) {
+            return false;
+        }
+
+        // Is file path
+        if (preg_match('/^(https?:\/\/|www\.|[a-z0-9]+\.[a-z]+)/i', $input) ||
+            strpos($input, '/') === 0 ||
+            strpos($input, './') === 0 ||
+            strpos($input, '../') === 0 ||
+            strpos($input, 'data:') === 0) {
+            return true;
+        }
+    
+        return false;
+    }
+
+    /**
      * Check if the path is a regular file and can be read.
      *
      * @param string $path
@@ -466,6 +503,16 @@ abstract class Minify
      */
     protected function canImportFile($path)
     {
+        // Not file if path is empty
+        if(empty($path)){
+            return false;
+        }
+
+        // Not file? Return false
+        if (!$this->detectUrlType($path)) {
+            return false;
+        }
+
         $parsed = parse_url($path);
         if (
             // file is elsewhere

--- a/lib/css_js_min/pathconverter/converter.cls.php
+++ b/lib/css_js_min/pathconverter/converter.cls.php
@@ -48,25 +48,27 @@ class Converter implements ConverterInterface
      */
     public function __construct($from, $to, $root = '')
     {
-        $shared = $this->shared($from, $to);
-        if ($shared === '') {
-            // when both paths have nothing in common, one of them is probably
-            // absolute while the other is relative
-            $root = $root ?: getcwd();
-            $from = strpos($from, $root) === 0 ? $from : preg_replace('/\/+/', '/', $root.'/'.$from);
-            $to = strpos($to, $root) === 0 ? $to : preg_replace('/\/+/', '/', $root.'/'.$to);
+        if(!empty($from)){
+            $shared = $this->shared($from, $to);
+            if ($shared === '') {
+                // when both paths have nothing in common, one of them is probably
+                // absolute while the other is relative
+                $root = $root ?: getcwd();
+                $from = strpos($from, $root) === 0 ? $from : preg_replace('/\/+/', '/', $root.'/'.$from);
+                $to = strpos($to, $root) === 0 ? $to : preg_replace('/\/+/', '/', $root.'/'.$to);
 
-            // or traveling the tree via `..`
-            // attempt to resolve path, or assume it's fine if it doesn't exist
-            $from = @realpath($from) ?: $from;
-            $to = @realpath($to) ?: $to;
+                // or traveling the tree via `..`
+                // attempt to resolve path, or assume it's fine if it doesn't exist
+                $from = @realpath($from) ?: $from;
+                $to = @realpath($to) ?: $to;
+            }
+
+            $from = $this->dirname($from);
+            $to = $this->dirname($to);
+
+            $from = $this->normalize($from);
+            $to = $this->normalize($to);
         }
-
-        $from = $this->dirname($from);
-        $to = $this->dirname($to);
-
-        $from = $this->normalize($from);
-        $to = $this->normalize($to);
 
         $this->from = $from;
         $this->to = $to;
@@ -191,6 +193,10 @@ class Converter implements ConverterInterface
      */
     protected function dirname($path)
     {
+        if(empty($path)){
+            return $path;
+        }
+
         if (@is_file($path)) {
             return dirname($path);
         }


### PR DESCRIPTION
Topic: [https://wordpress.org/support/topic/v7-multiple-css-file-path-errors](https://wordpress.org/support/topic/v7-multiple-css-file-path-errors)

Problem: When **open_basedir** restriction is set, the site will throw errors.
What is fixed: added tests for possible ways to stop **open_basedir** errors to appear.