### PR TITLE
Fix Media delete

### DIFF
--- a/src/core.cls.php
+++ b/src/core.cls.php
@@ -178,6 +178,9 @@ class Core extends Root
 			$this->cls('Admin');
 		}
 
+		// Hook to attachment delete action
+		add_action('delete_attachment', 'LiteSpeed\Media::delete_attachment', 11, 2);
+
 		if (defined('LITESPEED_DISABLE_ALL') && LITESPEED_DISABLE_ALL) {
 			Debug2::debug('[Core] Bypassed due to debug disable all setting');
 			return;

--- a/src/media.cls.php
+++ b/src/media.cls.php
@@ -150,7 +150,7 @@ class Media extends Root
 		add_action('litespeed_media_row', array($this, 'media_row_con'));
 
 		// Hook to attachment delete action
-		add_action('delete_attachment', __CLASS__ . '::delete_attachment');
+		// add_action('delete_attachment', __CLASS__ . '::delete_attachment');
 	}
 
 	/**


### PR DESCRIPTION
Media delete is not working when run from AJAX.

### How to reproduce:
Go to Media
Switch style to grid
Upload a image
Run optimization
Go back to media
Choose a image
Delete from popup(bottom right, click on **Delete permanently**)

### Fix
This PR will delete the images when added from AJAX request