### PR TITLE
Fix ticket #934261

### DIFF
--- a/src/esi.cls.php
+++ b/src/esi.cls.php
@@ -803,6 +803,8 @@ class ESI extends Root {
 	 * @since 1.1.3
 	 */
 	public function load_admin_bar_block( $params ) {
+		global $wp_the_query;
+
 		if (!empty($params['ref'])) {
 			$ref_qs = parse_url($params['ref'], PHP_URL_QUERY);
 			if (!empty($ref_qs)) {
@@ -815,8 +817,11 @@ class ESI extends Root {
 				}
 			}
 		}
+
 		// Needed when permalink structure is "Plain"
-		wp();
+		if (!isset($wp_the_query)) {
+			wp();
+		}
 
 		wp_admin_bar_render();
 		if (!$this->conf(Base::O_ESI_CACHE_ADMBAR)) {


### PR DESCRIPTION
Problem: When ESI is enabled there is situation where: edit item and items in WP admin bar were not showing.

Post forum: https://wordpress.org/support/topic/admin-edit-post-does-not-appear-on-admin-bar-inside-an-article/#post-18467868