### PR TITLE
Crawler - fix returned status when header value is "bkn"

### DIFF
--- a/src/crawler.cls.php
+++ b/src/crawler.cls.php
@@ -1038,10 +1038,13 @@ class Crawler extends Root {
 			return self::STATUS_NOCACHE; // Blacklist
 		}
 
-		$_cache_headers = array( 'x-qc-cache', 'x-lsadc-cache', 'x-litespeed-cache' );
+		$_cache_headers = array( 'x-litespeed-cache', 'x-qc-cache', 'x-lsadc-cache' );
 
 		foreach ($_cache_headers as $_header) {
 			if (stripos($header, $_header) !== false) {
+				if (stripos($header, $_header . ': bkn') !== false) {
+					return self::STATUS_HIT; // Hit
+				}
 				if (stripos($header, $_header . ': miss') !== false) {
 					return self::STATUS_MISS; // Miss
 				}


### PR DESCRIPTION
Fix crawler status to take **x-litespeed-cache: bkn** into account
Thanks @qtwrk :)

Internal link: [https://litespeedtech.slack.com/archives/C3PJPKE9G/p1749232192142149](https://litespeedtech.slack.com/archives/C3PJPKE9G/p1749232192142149)