### PR TITLE
Import settings - Fix download file on mobile 

### DIFF
--- a/src/import.cls.php
+++ b/src/import.cls.php
@@ -32,7 +32,8 @@ class Import extends Base {
 	/**
 	 * Export settings to file
 	 *
-	 * @since  1.8.2
+	 * @since 1.8.2
+	 * @since 7.3 added download content type
 	 * @access public
 	 */
 	public function export( $only_data_return = false ) {
@@ -58,6 +59,7 @@ class Import extends Base {
 
 		Debug2::debug('Import: Saved to ' . $filename);
 
+		@header('Content-Type: application/octet-stream');
 		@header('Content-Disposition: attachment; filename=' . $filename);
 		echo $data;
 


### PR DESCRIPTION
On mobile downloaded file it get added a .html extension at the end.
This fix will fix this behaviour.

Ticket: https://wordpress.org/support/topic/export-on-phone-file-extension-html/