### PR TITLE
Import - fix file name on mobile downlaod

### DIFF
--- a/src/import.cls.php
+++ b/src/import.cls.php
@@ -58,6 +58,7 @@ class Import extends Base {
 
 		Debug2::debug('Import: Saved to ' . $filename);
 
+		@header('Content-Type: application/octet-stream');
 		@header('Content-Disposition: attachment; filename=' . $filename);
 		echo $data;
 


### PR DESCRIPTION
Add file type to keep the correct filename on download file on mobile

Topic: https://wordpress.org/support/topic/export-on-phone-file-extension-html