### PR TITLE
Fix Learn More link

### DIFF
--- a/tpl/crawler/blacklist.tpl.php
+++ b/tpl/crawler/blacklist.tpl.php
@@ -25,7 +25,7 @@ $pagination      = Utility::pagination( $count, 30 );
 
 <h3 class="litespeed-title">
 	<?php esc_html_e( 'Blocklist', 'litespeed-cache' ); ?>
-	<?php Doc::learn_more( 'https://docs.litespeedtech.com/lscache/lscwp/crawler/#blacklist-tab' ); ?>
+	<?php Doc::learn_more( 'https://docs.litespeedtech.com/lscache/lscwp/crawler/#blocklist-tab' ); ?>
 </h3>
 
 <?php echo esc_html__( 'Total', 'litespeed-cache' ) . ': ' . esc_html( $count ); ?>


### PR DESCRIPTION
Fix wrong link for Learn More. Topic: [https://wordpress.org/support/topic/learn-more-link-with-wrong/](https://wordpress.org/support/topic/learn-more-link-with-wrong/)