### PR TITLE
Fix description html

### DIFF
--- a/tpl/db_optm/manage.tpl.php
+++ b/tpl/db_optm/manage.tpl.php
@@ -103,7 +103,7 @@ $autoload_summary = DB_Optm::cls()->autoload_summary();
                     <?php echo esc_html( $v['title'] ); ?>
                     <span class="litespeed-panel-counter<?php echo $v['count'] > 0 ? '-red' : ''; ?>">(<?php echo esc_html( $v['count'] ); ?><?php echo DB_Optm::hide_more() ? '+' : ''; ?>)</span>
                 </div>
-                <span class="litespeed-panel-para"><?php echo esc_html( $v['desc'] ); ?></span>
+                <span class="litespeed-panel-para"><?php echo wp_kses_post( $v['desc'] ); ?></span>
             </section>
             <section class="litespeed-panel-wrapper-top-right">
                 <span class="litespeed-panel-top-right-icon<?php echo $v['count'] > 0 ? '-cross' : '-tick'; ?>"></span>


### PR DESCRIPTION
Fixed an error, in admin, database optimization options do not show the correct html.
<img width="406" height="333" alt="image" src="https://github.com/user-attachments/assets/3c48f1b1-d482-4121-bbb7-20939c0ad393" />

Reported by Ryan D on slack