### PR TITLE
Image optimization - replace original with scaled images

### DIFF
--- a/src/base.cls.php
+++ b/src/base.cls.php
@@ -218,6 +218,7 @@ class Base extends Root {
 	const O_MEDIA_VPI                        = 'media-vpi';
 	const O_MEDIA_VPI_CRON                   = 'media-vpi_cron';
 	const O_IMG_OPTM_JPG_QUALITY             = 'img_optm-jpg_quality';
+	const O_MEDIA_REP_W_SCALED               = 'media-replace_w_scaled';
 
 	// -------------------------------------------------- ##
 	// --------------     Image Optm    ----------------- ##
@@ -500,6 +501,7 @@ class Base extends Root {
 		self::O_MEDIA_LQIP_EXC => array(),
 		self::O_MEDIA_VPI => false,
 		self::O_MEDIA_VPI_CRON => false,
+		self::O_MEDIA_REP_W_SCALED => false,
 
 		// Image Optm
 		self::O_IMG_OPTM_AUTO => false,

--- a/src/lang.cls.php
+++ b/src/lang.cls.php
@@ -202,6 +202,7 @@ class Lang extends Base {
 			self::O_MEDIA_ADD_MISSING_SIZES => __('Add Missing Sizes', 'litespeed-cache'),
 			self::O_MEDIA_VPI => __('Viewport Images', 'litespeed-cache'),
 			self::O_MEDIA_VPI_CRON => __('Viewport Images Cron', 'litespeed-cache'),
+			self::O_MEDIA_REP_W_SCALED => __('Replace Original with Scaled', 'litespeed-cache'),
 
 			self::O_IMG_OPTM_AUTO => __('Auto Request Cron', 'litespeed-cache'),
 			self::O_IMG_OPTM_ORI => __('Optimize Original Images', 'litespeed-cache'),

--- a/src/media.cls.php
+++ b/src/media.cls.php
@@ -52,11 +52,18 @@ class Media extends Root {
 	/**
 	 * Hooks after user init
 	 *
-	 * @since  7.2
+	 * @since 7.2
+	 * @since 7.4 Add media replace original with scaled.
 	 */
 	public function after_user_init() {
 		// Hook to attachment delete action (PR#844, Issue#841) for AJAX del compatibility
 		add_action('delete_attachment', array( $this, 'delete_attachment' ), 11, 2);
+
+		// For big images, allow to replace original with scaled image.
+		if( $this->conf(Base::O_MEDIA_REP_W_SCALED) ){
+			// Added priority 9 to happen before other functions added.
+			add_filter('wp_update_attachment_metadata', array( $this, 'replace_original_with_scaled' ), 9, 2);
+		}
 	}
 
 	/**
@@ -96,6 +103,47 @@ class Media extends Root {
 		add_filter('litespeed_buffer_finalize', array( $this, 'finalize' ), 4);
 
 		add_filter('litespeed_optm_html_head', array( $this, 'finalize_head' ));
+	}
+
+	/**
+	 * Handle attachment create
+	 * 
+	 * @param array $metadata Current meta array.
+	 * @param int $attachment_id Attachment ID.
+	 * @return array $metadata
+	 * @since  7.4
+	 */
+	public function replace_original_with_scaled( $metadata, $attachment_id ) {
+		// Test if create and image was resized.
+		if( $metadata && isset($metadata['original_image']) && isset($metadata['file']) && false !== strstr($metadata['file'], '-scaled')){
+			// Get rescaled file name.
+			$path_exploded      = explode( '/', strrev($metadata['file']), 2 );
+			$rescaled_file_name = strrev($path_exploded[0]);
+			
+			// Create paths for images: resized and original.
+			$base_path     = $this->_wp_upload_dir['basedir'] . $this->_wp_upload_dir['subdir'] . '/';
+			$rescaled_path = $base_path . $rescaled_file_name;
+			$new_path      = $base_path . $metadata['original_image'];
+
+			if( file_exists( $rescaled_path ) && file_exists( $new_path ) ){
+				// Move rescaled to original.
+				rename( $rescaled_path, $new_path );
+
+				// Change array file key.
+				$metadata['file'] = $this->_wp_upload_dir['subdir'] . '/' . $metadata['original_image'];
+				if( 0 === strpos( $metadata['file'], '/' ) ){
+					$metadata['file'] = substr( $metadata['file'], 1 );
+				}
+
+				// Delete array "original_image" key.
+				unset($metadata['original_image']);
+
+				// Update meta "_wp_attached_file".
+				update_post_meta( $attachment_id, '_wp_attached_file', $metadata['file'] );
+			}
+		}
+
+		return $metadata;
 	}
 
 	/**

--- a/tpl/page_optm/settings_media.tpl.php
+++ b/tpl/page_optm/settings_media.tpl.php
@@ -18,6 +18,8 @@ $closest_server = Cloud::get_summary( 'server.' . Cloud::SVC_LQIP );
 
 $lqip_queue = $this->load_queue( 'lqip' );
 
+$scaled_size = apply_filters( 'big_image_size_threshold', 2560 ) . 'px';
+
 ?>
 
 <h3 class="litespeed-title-short">
@@ -271,6 +273,39 @@ $lqip_queue = $this->load_queue( 'lqip' );
 					<?php esc_html_e( 'The image compression quality setting of WordPress out of 100.', 'litespeed-cache' ); ?>
 					<?php $this->recommended( $option_id ); ?>
 					<?php $this->_validate_ttl( $option_id, 0, 100 ); ?>
+				</div>
+			</td>
+		</tr>
+
+		<tr>
+			<th>
+				<?php $option_id = Base::O_MEDIA_REP_W_SCALED; ?>
+				<?php $this->title( $option_id ); ?>
+			</th>
+			<td>
+				<?php $this->build_switch( $option_id ); ?>
+				<div class="litespeed-desc">
+					<?php esc_html_e( 'Automatically replace large images with scaled versions.', 'litespeed-cache' ); ?>
+					<br />
+					<?php echo wp_kses_post( sprintf( __( 'Scaled size and threshold is: %s', 'litespeed-cache' ), '<code>' . $scaled_size . '</code>' ) ); ?>
+					<br />
+					<span class="litespeed-success">
+						<?php
+						printf(
+							esc_html__( 'API: Filter %s available to change threshold.', 'litespeed-cache' ),
+							'<code>big_image_size_threshold</code>'
+						);
+						?>
+						<a href="https://developer.wordpress.org/reference/hooks/big_image_size_threshold/" target="_blank" class="litespeed-learn-more">
+							<?php esc_html_e('Learn More', 'litespeed-cache'); ?>
+						</a>
+					</span>
+
+					<br />
+					<font class="litespeed-danger">
+						🚨
+						<?php esc_html_e( 'This is irreversible.', 'litespeed-cache' ); ?>
+					</font>
 				</div>
 			</td>
 		</tr>


### PR DESCRIPTION
Allow users to replace original image with the scaled version of image.
Will allow user to change scaled size by using filter `big_image_size_threshold`. More info: [https://developer.wordpress.org/reference/hooks/big_image_size_threshold/](https://developer.wordpress.org/reference/hooks/big_image_size_threshold/)