### PR TITLE
Allow purge CSS/JS from public function

### DIFF
--- a/src/purge.cls.php
+++ b/src/purge.cls.php
@@ -348,7 +348,26 @@ class Purge extends Base {
 	}
 
 	/**
-	 * Alerts LiteSpeed Web Server to purge pages.
+	 * Alerts LiteSpeed Web Server to purge CSS/JS entries. Public function.
+	 *
+	 * @since    7.6
+	 * @access   public
+	 */
+	public function purge_all_cssjs( $silence = false, $reason = false ) {
+		if( $reason ){
+			self::cls()->_purge_all_cssjs($silence);
+
+			if ( $reason ) {
+				self::debug('Cleared CSS/JS. Reason: ' . $reason);
+			}
+		}
+		else{
+			self::debug('Cannot clear CSS/JS. Reason is not added.');
+		}
+	}
+
+	/**
+	 * Alerts LiteSpeed Web Server to purge CSS/JS entries. Private function.
 	 *
 	 * @since    1.2.2
 	 * @access   private


### PR DESCRIPTION
After talking here: https://github.com/litespeedtech/lscache_wp/issues/895
It might be a good thing to allow plugins/themes to purge this CSS/JS cache BUT enforce to add reason for purge.

If the idea is ok, I can add to other purge functions.