### PR TITLE
Add compatibility for other plugins that use big_image_size_threshold

### DIFF
--- a/tpl/page_optm/settings_media.tpl.php
+++ b/tpl/page_optm/settings_media.tpl.php
@@ -18,7 +18,7 @@ $closest_server      = Cloud::get_summary( 'server.' . Cloud::SVC_LQIP );
 
 $lqip_queue = $this->load_queue( 'lqip' );
 
-$scaled_size = apply_filters( 'big_image_size_threshold', 2560 ) . 'px';
+$scaled_size = apply_filters( 'big_image_size_threshold', 2560, [], '', 0 ) . 'px';
 
 ?>
 


### PR DESCRIPTION
Added fix for topic: [https://wordpress.org/support/topic/collision-with-image-regenerate-select-crop-plugin/#post-18650101](https://wordpress.org/support/topic/collision-with-image-regenerate-select-crop-plugin/#post-18650101)