### PR TITLE
Network - fix save cache drop qs

### DIFF
--- a/data/const.network_default.json
+++ b/data/const.network_default.json
@@ -6,6 +6,7 @@
 	"cache-browser": false,
 	"cache-mobile": false,
 	"cache-mobile_rules": "Mobile\nAndroid\nSilk/\nKindle\nBlackBerry\nOpera Mini\nOpera Mobi",
+	"cache-drop_qs": "fbclid\ngclid\nutm*\n_ga",
 	"cache-login_cookie": "",
 	"cache-exc_cookies": "",
 	"cache-exc_useragents": "",

--- a/src/base.cls.php
+++ b/src/base.cls.php
@@ -590,6 +590,7 @@ class Base extends Root {
 		self::O_CACHE_BROWSER => false,
 		self::O_CACHE_MOBILE => false,
 		self::O_CACHE_MOBILE_RULES => [],
+		self::O_CACHE_DROP_QS => [],
 		self::O_CACHE_LOGIN_COOKIE => '',
 		self::O_CACHE_VARY_COOKIES => [],
 		self::O_CACHE_EXC_COOKIES => [],


### PR DESCRIPTION
Fix Drop QS save setting on network level.
Topic: [https://wordpress.org/support/topic/drop-query-string-option-not-saving-in-network-installation](https://wordpress.org/support/topic/drop-query-string-option-not-saving-in-network-installation)