### PR TITLE
Fix PHP 7.2 compatibility

### DIFF
--- a/src/admin-display.cls.php
+++ b/src/admin-display.cls.php
@@ -357,7 +357,7 @@ class Admin_Display extends Base {
 			'LiteSpeed Cache',
 			'LiteSpeed Cache',
 			$capability,
-			'litespeed',
+			'litespeed'
 		);
 
 		foreach ( $this->_pages as $slug => $meta ) {


### PR DESCRIPTION
Report: https://wordpress.org/support/topic/litespeed-parse-error-syntax-error-unexpected-2