### PR TITLE
Fix dns_preconnect usage in dns_optm_filter

### DIFF
--- a/src/optimize.cls.php
+++ b/src/optimize.cls.php
@@ -706,7 +706,7 @@ class Optimize extends Base {
 			}
 		}
 		if ('preconnect' === $relation_type) {
-			foreach ($this->dns_prefetch as $v) {
+			foreach ($this->dns_preconnect as $v) {
 				if ($v) {
 					$urls[] = $v;
 				}


### PR DESCRIPTION
Fixes the problem described in https://github.com/litespeedtech/lscache_wp/issues/921.