### PR TITLE
fix(woocommerce): purge cache when scheduled sales start or end

### DIFF
--- a/thirdparty/woocommerce.cls.php
+++ b/thirdparty/woocommerce.cls.php
@@ -82,6 +82,14 @@ class WooCommerce extends Base {
 		add_action('woocommerce_product_set_stock', [ $this, 'purge_product' ]);
 		add_action('woocommerce_variation_set_stock', [ $this, 'purge_product' ]); // #984479 Update variations stock
 
+		// Purge cache when scheduled sales start or end (daily cron safety net).
+		add_action( 'wc_after_products_starting_sales', [ $this, 'purge_sale_products' ] );
+		add_action( 'wc_after_products_ending_sales', [ $this, 'purge_sale_products' ] );
+
+		// Purge cache for per-product scheduled sale events (WooCommerce 10.5.0+).
+		add_action( 'wc_product_start_scheduled_sale', [ $this, 'purge_sale_product_by_id' ] );
+		add_action( 'wc_product_end_scheduled_sale', [ $this, 'purge_sale_product_by_id' ] );
+
 		add_action('comment_post', [ $this, 'add_review' ], 10, 3);
 
 		if ( $this->esi_enabled ) {
@@ -711,6 +719,58 @@ class WooCommerce extends Base {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Purge cache for products affected by scheduled sales.
+	 *
+	 * Hooked to `wc_after_products_starting_sales` and `wc_after_products_ending_sales`
+	 * which fire during the daily `woocommerce_scheduled_sales` cron event.
+	 *
+	 * @since 6.7
+	 * @access public
+	 *
+	 * @param array $product_ids Array of product IDs whose sale status changed.
+	 * @return void
+	 */
+	public function purge_sale_products( $product_ids ) {
+		if ( empty( $product_ids ) || ! is_array( $product_ids ) ) {
+			return;
+		}
+
+		do_action( 'litespeed_debug', '[3rd] Woo Scheduled sales purge [hook] ' . current_filter() . ' [count] ' . count( $product_ids ) );
+
+		foreach ( $product_ids as $product_id ) {
+			$product_id = absint( $product_id );
+			if ( ! $product_id ) {
+				continue;
+			}
+
+			do_action( 'litespeed_debug', '[3rd] Woo Scheduled sale purge [pid] ' . $product_id );
+			do_action( 'litespeed_purge_post', $product_id );
+
+			// Also purge related category and tag pages.
+			$this->backend_purge( $product_id );
+		}
+
+		// Purge the shop page as sale products may appear there.
+		do_action( 'litespeed_purge', self::CACHETAG_SHOP );
+	}
+
+	/**
+	 * Purge cache for a single product when its scheduled sale starts or ends.
+	 *
+	 * Hooked to `wc_product_start_scheduled_sale` and `wc_product_end_scheduled_sale`
+	 * which fire via per-product Action Scheduler events (WooCommerce 10.5.0+).
+	 *
+	 * @since 6.7
+	 * @access public
+	 *
+	 * @param int $product_id Product ID whose sale status changed.
+	 * @return void
+	 */
+	public function purge_sale_product_by_id( $product_id ) {
+		$this->purge_sale_products( [ $product_id ] );
 	}
 
 	/**


### PR DESCRIPTION
## 🎯 Summary

This PR implements cache purging when WooCommerce scheduled sales start or end. It hooks into both the legacy daily cron actions and the newer per-product Action Scheduler events (WooCommerce 10.5.0+) to ensure product prices are always up-to-date on the frontend.

## 📋 Issue Reference

Fixes #941

## 🔍 Problem Description

### Current Behavior
When a scheduled sale starts or ends via WooCommerce's automation (cron or Action Scheduler), the product page cache is not purged. This results in stale prices being displayed to visitors until the cache expires or is manually cleared.

### Expected Behavior
Product pages should be automatically purged from the cache the moment a scheduled sale starts or ends, ensuring the correct sale/regular price is immediately visible.

### Root Cause
The plugin previously lacked hooks listening to `woocommerce_scheduled_sales` related actions. While `set_tag()` handles TTL for sales, it only applies when a page is visited *before* it is cached, not for already cached pages.

## ✨ Solution Overview

### Approach Taken
We hook into four specific WooCommerce actions to cover all scenarios:

1. **Legacy / Daily Cron Safety Net**:
   - `wc_after_products_starting_sales`
   - `wc_after_products_ending_sales`
   - These provide an array of product IDs processed by the daily cron.

2. **Modern / Per-Product Action Scheduler (WC 10.5.0+)**:
   - `wc_product_start_scheduled_sale`
   - `wc_product_end_scheduled_sale`
   - These provide a single product ID for precise, timely updates.

### Why This Approach
This dual approach ensures compatibility with older WooCommerce versions while leveraging the precision of the new Action Scheduler system. It avoids purging the entire cache ("Purge All") which would be performance-heavy, instead targeting only affected products and their related taxonomy pages.

## 🔧 Changes Made

### Files Modified
- `thirdparty/woocommerce.cls.php`: Added hooks in `add_hooks()` and implemented `purge_sale_products()` and `purge_sale_product_by_id()` methods.

### Detailed Changes

#### 1. Hooks Registration (`add_hooks`)

**New Hooks:**
```php
// Daily cron safety net
add_action( 'wc_after_products_starting_sales', [ $this, 'purge_sale_products' ] );
add_action( 'wc_after_products_ending_sales', [ $this, 'purge_sale_products' ] );

// Per-product AS events (WC 10.5+)
add_action( 'wc_product_start_scheduled_sale', [ $this, 'purge_sale_product_by_id' ] );
add_action( 'wc_product_end_scheduled_sale', [ $this, 'purge_sale_product_by_id' ] );
```

#### 2. Purge Logic (`purge_sale_products`)

**Implementation:**
```php
public function purge_sale_products( $product_ids ) {
    // ... validation ...
    foreach ( $product_ids as $product_id ) {
        // Purge product page
        do_action( 'litespeed_purge_post', $product_id );
        // Purge related categories/tags
        $this->backend_purge( $product_id );
    }
    // Purge shop page
    do_action( 'litespeed_purge', self::CACHETAG_SHOP );
}
```

**Why This Works:**
It reuses the existing `litespeed_purge_post` action and `backend_purge()` method, ensuring consistency with how manual product updates are handled.

## 🧪 Testing Performed

### Manual Testing

#### Test Case 1: Scheduled Sale Start (Action Scheduler)
**Steps:**
1. Set a product's sale start date to 1 minute in the future.
2. Visit the product page to cache it (showing regular price).
3. Wait for the AS action `wc_product_start_scheduled_sale` to fire.
4. Reload product page.

**Expected Result:** Cache is purged, sale price appears.
**Actual Result:** ✅ Verified (simulated via manual hook trigger).

#### Test Case 2: Daily Cron Fallback
**Steps:**
1. Simulate `wc_after_products_starting_sales` with a product ID array.
2. Check debug log for `[3rd] Woo Scheduled sales purge`.

**Actual Result:** ✅ Verified debug logs show correct purge events.

## 📊 Performance Impact

- **Before:** No purge (stale content).
- **After:** Targeted purge of specific products + shop page.
- **Analysis:** Negligible impact. Much more efficient than a "Purge All" approach.

## 🔒 Security Considerations

- ✅ Used `absint()` on product IDs before processing.
- ✅ Checked for array validity.
- ✅ No user input processing involved (internal hooks only).

## 📚 Documentation Updates

- ✅ Added PHPDoc blocks for new methods.

## ⚠️ Breaking Changes

✅ **No breaking changes**

## ✅ PR Checklist

- [x] Code follows WordPress Coding Standards
- [x] All functions have proper PHPDoc blocks
- [x] Input sanitized, output escaped
- [x] Backward compatible
- [x] Self-reviewed for quality

---

**Ready for Review** ✨