### PR TITLE
Fix LQIP generation failing for native WebP/AVIF images

### DIFF
--- a/src/utility.cls.php
+++ b/src/utility.cls.php
@@ -446,10 +446,26 @@ class Utility extends Root {
 	 * @return string Cleaned filename.
 	 */
 	public static function drop_webp( $filename ) {
-		if ( in_array( substr( $filename, -5 ), [ '.webp', '.avif' ], true ) ) {
-			$filename = substr( $filename, 0, -5 );
+		$path = (string) wp_parse_url( $filename, PHP_URL_PATH );
+		if ( ! $path ) {
+			$path = $filename;
 		}
 
+		$base_ext = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+		if ( ! in_array( $base_ext, [ 'webp', 'avif' ], true ) ) {
+			return $filename;
+		}
+
+		$name_without_ext = pathinfo( $path, PATHINFO_FILENAME );
+		$prev_ext         = strtolower( pathinfo( $name_without_ext, PATHINFO_EXTENSION ) );
+
+		// Only drop optimized suffix when a source extension exists, e.g. `.png.webp`.
+		if ( ! $prev_ext ) {
+			return $filename;
+		}
+
+		$filename = substr( $filename, 0, -strlen( $base_ext ) - 1 );
+		
 		return $filename;
 	}
 

--- a/src/utility.cls.php
+++ b/src/utility.cls.php
@@ -462,8 +462,8 @@ class Utility extends Root {
 			return $filename;
 		}
 
-		// Drop the trailing `.webp`/`.avif` suffix now that a source extension underneath is confirmed.
-		return substr( $filename, 0, -strlen( $base_ext ) - 1 );
+		// Remove the `.webp`/`.avif` suffix only, preserving any query string or fragment (lazyload can pass raw cache-busted `<img src>` URLs).
+		return preg_replace( '~\.' . $base_ext . '(?=$|[?#])~i', '', $filename, 1 );
 	}
 
 	/**

--- a/src/utility.cls.php
+++ b/src/utility.cls.php
@@ -456,17 +456,14 @@ class Utility extends Root {
 			return $filename;
 		}
 
-		$name_without_ext = pathinfo( $path, PATHINFO_FILENAME );
-		$prev_ext         = strtolower( pathinfo( $name_without_ext, PATHINFO_EXTENSION ) );
-
-		// Only drop optimized suffix when a source extension exists, e.g. `.png.webp`.
-		if ( ! $prev_ext ) {
+		// Only strip the optimized suffix when a real source image extension exists underneath, e.g. `.png.webp`. Native `image.webp` is returned unchanged.
+		$prev_ext = strtolower( pathinfo( pathinfo( $path, PATHINFO_FILENAME ), PATHINFO_EXTENSION ) );
+		if ( ! in_array( $prev_ext, [ 'png', 'jpg', 'jpeg', 'gif', 'bmp' ], true ) ) {
 			return $filename;
 		}
 
-		$filename = substr( $filename, 0, -strlen( $base_ext ) - 1 );
-		
-		return $filename;
+		// Drop the trailing `.webp`/`.avif` suffix now that a source extension underneath is confirmed.
+		return substr( $filename, 0, -strlen( $base_ext ) - 1 );
 	}
 
 	/**


### PR DESCRIPTION
## Problem

LQIP generation fails for natively uploaded WebP and AVIF images. The `Utility::drop_webp()` function unconditionally strips `.webp`/`.avif` extensions, which breaks URLs for native WebP/AVIF files that don't have a double extension (e.g., `image.webp` vs `image.png.webp`).

**Example:**
- `image.png.webp` → `image.png` Success (LiteSpeed optimized, has source extension)
- `image.webp` → `image`  Fails (native WebP, results in 404)

This causes the LQIP service to either:
1. Get a 404 response and add the image to the exclude list 
2. Receive an HTML error page instead of image data (`Unsupported response content-type text/html`) and add the image to the exclude list 

## Fix

Refactored `Utility::drop_webp()` to only strip the `.webp`/`.avif` suffix when a valid source extension exists underneath (double-extension pattern like `.png.webp`). Native WebP/AVIF URLs are now returned unchanged.

## Changes

- `src/utility.cls.php` — Updated `drop_webp()` to use `pathinfo()` for proper extension detection instead of blind `substr()` stripping.