### PR TITLE
Fix LQIP manual queue run not showing loading screen and being uncancellable

### DIFF
--- a/src/placeholder.cls.php
+++ b/src/placeholder.cls.php
@@ -461,6 +461,13 @@ class Placeholder extends Base {
 			if ( ! $do_continue ) {
 				return;
 			}
+
+			// Show loading screen and self-redirect for next request
+			$queue = $_instance->load_queue( 'lqip' );
+    		if ( ! empty( $queue ) ) {
+        		GUI::print_loading( count( $queue ), 'LQIP' );
+        		return Router::self_redirect( Router::ACTION_PLACEHOLDER, self::TYPE_GENERATE );
+    		}
 		}
 	}
 

--- a/tpl/page_optm/settings_media.tpl.php
+++ b/tpl/page_optm/settings_media.tpl.php
@@ -215,7 +215,7 @@ $scaled_size = apply_filters( 'big_image_size_threshold', 2560, [], '', 0 ) . 'p
 							</p>
 						</div>
 						<a href="<?php echo esc_url( Utility::build_url( Router::ACTION_PLACEHOLDER, Placeholder::TYPE_GENERATE ) ); ?>" class="button litespeed-btn-success">
-							<?php esc_html_e( 'Run Queue Manually', 'litespeed-cache' ); ?>
+							<?php printf( esc_html__( 'Run %s Queue Manually', 'litespeed-cache' ), 'LQIP' ); ?>
 						</a>
 						<?php Doc::queue_issues(); ?>
 					<?php endif; ?>


### PR DESCRIPTION
### Description:

When clicking "**Run Queue Manually**" for LQIP, it processes the entire queue in a single request without showing the loading screen or cancel option. This is different from how UCSS, CCSS, and VPI work; those show an "**X files left in queue**" screen with a Cancel link between each batch.

Because everything runs in **one PHP request**, the user can not cancel it. Even closing the browser tab does not stop it. The server-side process keeps running until the queue is fully cleared, the service quota runs out, or some other server/network error interrupts it. This can cause unnecessary server load, especially with larger queues.

### Changes:

- Added `GUI::print_loading()` and `Router::self_redirect()` after each LQIP request in `cron()`, so it follows the same redirect-loop pattern as UCSS/CCSS/VPI
- Fixed the button label from "Run Queue Manually" to "**Run LQIP Queue Manually**" to stay consistent with the other services