### PR TITLE
fix(admin): stop the wrong tab from flashing before page settles

### DIFF
--- a/assets/css/litespeed.css
+++ b/assets/css/litespeed.css
@@ -527,6 +527,12 @@ button.litespeed-form-action:hover {
 	padding: 1px 20px 20px 20px;
 }
 
+/* Prevent tab-flash before JS runs: hide non-targeted layout panels at paint time. */
+/* jQuery .show()/.hide() write inline styles which override these rules afterwards. */
+.litespeed-body [data-litespeed-layout][id] { display: none; scroll-margin-top: 100px; }
+.litespeed-body [data-litespeed-layout][id]:target { display: block; }
+.litespeed-body:not(:has([data-litespeed-layout][id]:target)) [data-litespeed-default-tab="1"] { display: block; }
+
 @media screen and (min-width: 681px) {
 	.litespeed-header + .litespeed-body {
 		border-top: none;

--- a/assets/js/litespeed-cache-admin.js
+++ b/assets/js/litespeed-cache-admin.js
@@ -57,8 +57,16 @@
 				type = litespeed_tab_type(type);
 				var data = 'litespeed-' + type;
 				$elems.on('click', function (_event) {
-					litespeed_display_tab($(this).data(data), type);
-					document.cookie = 'litespeed_' + type + '=' + $(this).data(data);
+					var name = $(this).data(data);
+					// Don't scroll to the anchor; the fragment is still set below for sharing and the no-JS fallback.
+					if (_event && _event.preventDefault) {
+						_event.preventDefault();
+					}
+					litespeed_display_tab(name, type);
+					document.cookie = 'litespeed_' + type + '=' + name;
+					if (window.history && window.history.replaceState) {
+						window.history.replaceState(null, '', '#' + name);
+					}
 					$(this).blur();
 				});
 			};

--- a/tpl/cache/entry.tpl.php
+++ b/tpl/cache/entry.tpl.php
@@ -21,6 +21,9 @@ if ( $this->_is_network_admin ) {
 		'browser'  => __( 'Browser', 'litespeed-cache' ),
 		'advanced' => __( 'Advanced', 'litespeed-cache' ),
 	);
+
+	$cookie_tab        = isset( $_COOKIE['litespeed_tab'] ) ? sanitize_key( wp_unslash( $_COOKIE['litespeed_tab'] ) ) : '';
+	$default_tab_key   = isset( $menu_list[ $cookie_tab ] ) ? $cookie_tab : array_key_first( $menu_list );
 ?>
 
 <div class="wrap">
@@ -44,9 +47,10 @@ if ( $this->_is_network_admin ) {
 		$this->form_action( Router::ACTION_SAVE_SETTINGS_NETWORK );
 
 		foreach ( $menu_list as $k => $val ) {
-			$k_escaped = esc_attr( $k );
+			$k_escaped   = esc_attr( $k );
+			$is_default  = ( $k === $default_tab_key );
 			?>
-			<div data-litespeed-layout="<?php echo esc_html( $k_escaped ); ?>">
+			<div data-litespeed-layout="<?php echo esc_html( $k_escaped ); ?>" id="<?php echo esc_attr( $k_escaped ); ?>"<?php echo $is_default ? ' data-litespeed-default-tab="1"' : ''; ?>>
 			<?php
 			require LSCWP_DIR . "tpl/cache/network_settings-$k.tpl.php";
 			?>
@@ -76,6 +80,10 @@ if ( ! $this->_is_multisite ) {
 }
 
 $menu_list['advanced'] = __( 'Advanced', 'litespeed-cache' );
+
+// Pick the active tab server-side so the right panel paints before JS runs.
+$cookie_tab      = isset( $_COOKIE['litespeed_tab'] ) ? sanitize_key( wp_unslash( $_COOKIE['litespeed_tab'] ) ) : '';
+$default_tab_key = isset( $menu_list[ $cookie_tab ] ) ? $cookie_tab : array_key_first( $menu_list );
 
 /**
  * Generate roles for setting usage
@@ -137,7 +145,8 @@ ksort( $roles );
 		require LSCWP_DIR . 'tpl/cache/more_settings_tip.tpl.php';
 
 		foreach ( $menu_list as $k => $val ) {
-			echo '<div data-litespeed-layout="' . esc_attr( $k ) . '">';
+			$is_default = ( $k === $default_tab_key );
+			echo '<div data-litespeed-layout="' . esc_attr( $k ) . '" id="' . esc_attr( $k ) . '"' . ( $is_default ? ' data-litespeed-default-tab="1"' : '' ) . '>';
 			require LSCWP_DIR . "tpl/cache/settings-$k.tpl.php";
 			echo '</div>';
 		}

--- a/tpl/cdn/entry.tpl.php
+++ b/tpl/cdn/entry.tpl.php
@@ -15,6 +15,10 @@ $menu_list = array(
 	'cf'    => esc_html__( 'Cloudflare', 'litespeed-cache' ),
 	'other' => esc_html__( 'Other Static CDN', 'litespeed-cache' ),
 );
+
+// Pick the active tab server-side so the right panel paints before JS runs.
+$cookie_tab      = isset( $_COOKIE['litespeed_tab'] ) ? sanitize_key( wp_unslash( $_COOKIE['litespeed_tab'] ) ) : '';
+$default_tab_key = isset( $menu_list[ $cookie_tab ] ) ? $cookie_tab : array_key_first( $menu_list );
 ?>
 
 <div class="wrap">
@@ -35,10 +39,8 @@ $menu_list = array(
 	<div class="litespeed-body">
 		<?php
 		foreach ( $menu_list as $menu_key => $menu_value ) {
-			printf(
-				'<div data-litespeed-layout="%s">',
-				esc_attr( $menu_key )
-			);
+			$is_default = ( $menu_key === $default_tab_key );
+			echo '<div data-litespeed-layout="' . esc_attr( $menu_key ) . '" id="' . esc_attr( $menu_key ) . '"' . ( $is_default ? ' data-litespeed-default-tab="1"' : '' ) . '>';
 			require LSCWP_DIR . "tpl/cdn/$menu_key.tpl.php";
 			echo '</div>';
 		}

--- a/tpl/crawler/entry.tpl.php
+++ b/tpl/crawler/entry.tpl.php
@@ -16,6 +16,10 @@ $menu_list = [
 	'blacklist' => esc_html__( 'Blocklist', 'litespeed-cache' ),
 	'settings'  => esc_html__( 'Settings', 'litespeed-cache' ),
 ];
+
+// Pick the active tab server-side so the right panel paints before JS runs.
+$cookie_tab      = isset( $_COOKIE['litespeed_tab'] ) ? sanitize_key( wp_unslash( $_COOKIE['litespeed_tab'] ) ) : '';
+$default_tab_key = isset( $menu_list[ $cookie_tab ] ) ? $cookie_tab : array_key_first( $menu_list );
 ?>
 
 <div class="wrap">
@@ -36,10 +40,8 @@ $menu_list = [
 	<div class="litespeed-body">
 		<?php
 		foreach ( $menu_list as $menu_key => $menu_value ) {
-			printf(
-				'<div data-litespeed-layout="%s">',
-				esc_attr( $menu_key )
-			);
+			$is_default = ( $menu_key === $default_tab_key );
+			echo '<div data-litespeed-layout="' . esc_attr( $menu_key ) . '" id="' . esc_attr( $menu_key ) . '"' . ( $is_default ? ' data-litespeed-default-tab="1"' : '' ) . '>';
 			require LSCWP_DIR . "tpl/crawler/$menu_key.tpl.php";
 			echo '</div>';
 		}

--- a/tpl/db_optm/entry.tpl.php
+++ b/tpl/db_optm/entry.tpl.php
@@ -17,6 +17,10 @@ if ( ! is_network_admin() ) {
     $menu_list['settings'] = esc_html__( 'DB Optimization Settings', 'litespeed-cache' );
 }
 
+// Pick the active tab server-side so the right panel paints before JS runs.
+$cookie_tab      = isset( $_COOKIE['litespeed_tab'] ) ? sanitize_key( wp_unslash( $_COOKIE['litespeed_tab'] ) ) : '';
+$default_tab_key = isset( $menu_list[ $cookie_tab ] ) ? $cookie_tab : array_key_first( $menu_list );
+
 ?>
 
 <div class="wrap">
@@ -37,7 +41,8 @@ if ( ! is_network_admin() ) {
     <div class="litespeed-body">
     <?php
         foreach ( $menu_list as $tab_key => $tab_val ) {
-			echo '<div data-litespeed-layout="' . esc_attr( $tab_key ) . '">';
+			$is_default = ( $tab_key === $default_tab_key );
+			echo '<div data-litespeed-layout="' . esc_attr( $tab_key ) . '" id="' . esc_attr( $tab_key ) . '"' . ( $is_default ? ' data-litespeed-default-tab="1"' : '' ) . '>';
 			require LSCWP_DIR . 'tpl/db_optm/' . $tab_key . '.tpl.php';
 			echo '</div>';
         }

--- a/tpl/general/entry.tpl.php
+++ b/tpl/general/entry.tpl.php
@@ -23,6 +23,10 @@ if ( is_network_admin() ) {
     );
 }
 
+// Pick the active tab server-side so the right panel paints before JS runs.
+$cookie_tab      = isset( $_COOKIE['litespeed_tab'] ) ? sanitize_key( wp_unslash( $_COOKIE['litespeed_tab'] ) ) : '';
+$default_tab_key = isset( $menu_list[ $cookie_tab ] ) ? $cookie_tab : array_key_first( $menu_list );
+
 ?>
 
 <div class="wrap">
@@ -43,7 +47,8 @@ if ( is_network_admin() ) {
     <div class="litespeed-body">
         <?php
         foreach ( $menu_list as $menu_key => $val ) {
-            echo '<div data-litespeed-layout="' . esc_attr( $menu_key ) . '">';
+            $is_default = ( $menu_key === $default_tab_key );
+            echo '<div data-litespeed-layout="' . esc_attr( $menu_key ) . '" id="' . esc_attr( $menu_key ) . '"' . ( $is_default ? ' data-litespeed-default-tab="1"' : '' ) . '>';
             require LSCWP_DIR . 'tpl/general/' . $menu_key . '.tpl.php';
             echo '</div>';
         }

--- a/tpl/img_optm/entry.tpl.php
+++ b/tpl/img_optm/entry.tpl.php
@@ -23,6 +23,10 @@ if ( is_network_admin() ) {
     );
 }
 
+// Pick the active tab server-side so the right panel paints before JS runs.
+$cookie_tab      = isset( $_COOKIE['litespeed_tab'] ) ? sanitize_key( wp_unslash( $_COOKIE['litespeed_tab'] ) ) : '';
+$default_tab_key = isset( $menu_list[ $cookie_tab ] ) ? $cookie_tab : array_key_first( $menu_list );
+
 ?>
 
 <div class="wrap">
@@ -43,7 +47,8 @@ if ( is_network_admin() ) {
     <div class="litespeed-body">
         <?php
         foreach ( $menu_list as $menu_key => $val ) {
-            echo '<div data-litespeed-layout="' . esc_attr( $menu_key ) . '">';
+            $is_default = ( $menu_key === $default_tab_key );
+            echo '<div data-litespeed-layout="' . esc_attr( $menu_key ) . '" id="' . esc_attr( $menu_key ) . '"' . ( $is_default ? ' data-litespeed-default-tab="1"' : '' ) . '>';
             require LSCWP_DIR . 'tpl/img_optm/' . $menu_key . '.tpl.php';
             echo '</div>';
         }

--- a/tpl/optimax/entry.tpl.php
+++ b/tpl/optimax/entry.tpl.php
@@ -23,6 +23,10 @@ if ( is_network_admin() ) {
     );
 }
 
+// Pick the active tab server-side so the right panel paints before JS runs.
+$cookie_tab      = isset( $_COOKIE['litespeed_tab'] ) ? sanitize_key( wp_unslash( $_COOKIE['litespeed_tab'] ) ) : '';
+$default_tab_key = isset( $menu_list[ $cookie_tab ] ) ? $cookie_tab : array_key_first( $menu_list );
+
 ?>
 
 <div class="wrap">
@@ -43,7 +47,8 @@ if ( is_network_admin() ) {
     <div class="litespeed-body">
         <?php
         foreach ( $menu_list as $menu_key => $val ) {
-            echo '<div data-litespeed-layout="' . esc_attr( $menu_key ) . '">';
+            $is_default = ( $menu_key === $default_tab_key );
+            echo '<div data-litespeed-layout="' . esc_attr( $menu_key ) . '" id="' . esc_attr( $menu_key ) . '"' . ( $is_default ? ' data-litespeed-default-tab="1"' : '' ) . '>';
             require LSCWP_DIR . 'tpl/optimax/' . $menu_key . '.tpl.php';
             echo '</div>';
         }

--- a/tpl/page_optm/entry.tpl.php
+++ b/tpl/page_optm/entry.tpl.php
@@ -24,6 +24,10 @@ $menu_list = array(
 	'settings_tuning_css'   => esc_html__( 'Tuning', 'litespeed-cache' ) . ' - CSS',
 );
 
+// Pick the active tab server-side so the right panel paints before JS runs.
+$cookie_tab      = isset( $_COOKIE['litespeed_tab'] ) ? sanitize_key( wp_unslash( $_COOKIE['litespeed_tab'] ) ) : '';
+$default_tab_key = isset( $menu_list[ $cookie_tab ] ) ? $cookie_tab : array_key_first( $menu_list );
+
 ?>
 
 <div class="wrap">
@@ -53,8 +57,9 @@ $menu_list = array(
 
 		// Include all tpl for faster UE
 		foreach ( $menu_list as $tab_key => $tab_val ) {
+			$is_default = ( $tab_key === $default_tab_key );
 			?>
-			<div data-litespeed-layout='<?php echo esc_attr( $tab_key ); ?>'>
+			<div data-litespeed-layout='<?php echo esc_attr( $tab_key ); ?>' id='<?php echo esc_attr( $tab_key ); ?>'<?php echo $is_default ? ' data-litespeed-default-tab="1"' : ''; ?>>
 				<?php require LSCWP_DIR . 'tpl/page_optm/' . $tab_key . '.tpl.php'; ?>
 			</div>
 			<?php

--- a/tpl/presets/entry.tpl.php
+++ b/tpl/presets/entry.tpl.php
@@ -16,6 +16,10 @@ $menu_list = array(
 	'standard'      => esc_html__( 'Standard Presets', 'litespeed-cache' ),
 	'import_export' => esc_html__( 'Import / Export', 'litespeed-cache' ),
 );
+
+// Pick the active tab server-side so the right panel paints before JS runs.
+$cookie_tab      = isset( $_COOKIE['litespeed_tab'] ) ? sanitize_key( wp_unslash( $_COOKIE['litespeed_tab'] ) ) : '';
+$default_tab_key = isset( $menu_list[ $cookie_tab ] ) ? $cookie_tab : array_key_first( $menu_list );
 ?>
 
 <div class="wrap">
@@ -36,8 +40,9 @@ $menu_list = array(
 	<div class="litespeed-body">
 		<?php
 		foreach ( $menu_list as $curr_tab => $val ) :
+			$is_default = ( $curr_tab === $default_tab_key );
 			?>
-			<div data-litespeed-layout="<?php echo esc_attr( $curr_tab ); ?>">
+			<div data-litespeed-layout="<?php echo esc_attr( $curr_tab ); ?>" id="<?php echo esc_attr( $curr_tab ); ?>"<?php echo $is_default ? ' data-litespeed-default-tab="1"' : ''; ?>>
 				<?php
 				if ( 'import_export' === $curr_tab ) {
 					require LSCWP_DIR . "tpl/toolbox/$curr_tab.tpl.php";

--- a/tpl/toolbox/entry.tpl.php
+++ b/tpl/toolbox/entry.tpl.php
@@ -34,6 +34,10 @@ if ( ! $this->_is_multisite || $this->_is_network_admin ) {
 	$menu_list['log_viewer']     = esc_html__( 'Log View', 'litespeed-cache' );
 	$menu_list['beta_test']      = esc_html__( 'Beta Test', 'litespeed-cache' );
 }
+
+// Pick the active tab server-side so the right panel paints before JS runs.
+$cookie_tab      = isset( $_COOKIE['litespeed_tab'] ) ? sanitize_key( wp_unslash( $_COOKIE['litespeed_tab'] ) ) : '';
+$default_tab_key = isset( $menu_list[ $cookie_tab ] ) ? $cookie_tab : array_key_first( $menu_list );
 ?>
 
 <div class="wrap">
@@ -53,7 +57,8 @@ if ( ! $this->_is_multisite || $this->_is_network_admin ) {
 
 	<div class="litespeed-body">
 		<?php foreach ( $menu_list as $curr_tab => $val ) : ?>
-			<div data-litespeed-layout="<?php echo esc_attr( $curr_tab ); ?>">
+			<?php $is_default = ( $curr_tab === $default_tab_key ); ?>
+			<div data-litespeed-layout="<?php echo esc_attr( $curr_tab ); ?>" id="<?php echo esc_attr( $curr_tab ); ?>"<?php echo $is_default ? ' data-litespeed-default-tab="1"' : ''; ?>>
 				<?php require LSCWP_DIR . "tpl/toolbox/$curr_tab.tpl.php"; ?>
 			</div>
 		<?php endforeach; ?>


### PR DESCRIPTION
When opening any LiteSpeed admin page with tabs (Cache, CDN, Crawler, etc.) the first tab briefly showed before jumping to the user's last-selected tab. The correct tab is now picked server-side from the remembered cookie, so the right panel paints straight away. Tab clicks also keep the URL fragment shareable without scrolling the page.