### PR TITLE
VPI: add fetchpriority=high to VPI preload links

### DIFF
--- a/src/media.cls.php
+++ b/src/media.cls.php
@@ -307,7 +307,7 @@ class Media extends Root {
 		// <link rel="preload" as="image" href="xx">
 		if ( $this->_vpi_preload_list ) {
 			foreach ( $this->_vpi_preload_list as $v ) {
-				$content .= '<link rel="preload" as="image" href="' . esc_url( Str::trim_quotes( $v ) ) . '">';
+				$content .= '<link rel="preload" fetchpriority="high" as="image" href="' . esc_url( Str::trim_quotes( $v ) ) . '">';
 			}
 		}
 		return $content;


### PR DESCRIPTION
Adds `fetchpriority="high"` to image preload links generated in `finalize_head()` to improve LCP resource prioritization.

This addresses the PageSpeed Insights warning about missing high fetch priority on the preloaded LCP image and helps browsers prioritize loading the main visual content earlier.

<img width="801" height="191" alt="Firefox_Screenshot_2026-05-29T10-12-02 575Z" src="https://github.com/user-attachments/assets/f5384393-9254-42bd-a7f6-7c43e75df062" />