### PR TITLE
OC - validate host

### DIFF
--- a/src/admin-settings.cls.php
+++ b/src/admin-settings.cls.php
@@ -221,6 +221,23 @@ class Admin_Settings extends Base {
 					$saved_sizes = isset( $raw_data[$id] ) ? $raw_data[$id] : [];
 					$data        = array_diff( $image_sizes, $saved_sizes );
 					break;
+					
+				case self::O_OBJECT_HOST: // The field accepts an IP, a hostname, or an absolute UNIX socket path.
+					$data  = trim( $raw_data[ $id ] );
+					$first = substr( $data, 0, 1 );
+
+					if ( '/' === $first ) {
+						$valid = true;
+					} else {
+						// will validate both hostname and IP. Values that start with ~ will be rejected by filter_var.
+						$valid = false !== filter_var( $data, FILTER_VALIDATE_IP ) || false !== filter_var( $data, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME );
+					}
+
+					if ( !$valid ) {
+						Admin_Display::error( __( 'Object Cache: Invalid host. Use an IP address, a hostname or an absolute UNIX socket path. Old value was restored.', 'litespeed-cache' ) );
+						$data = $this->conf( $id ); // Revert to existing value to avoid saving invalid data.
+					}
+					break;
 
 				default:
 					break;

--- a/tpl/cache/settings_inc.object.tpl.php
+++ b/tpl/cache/settings_inc.object.tpl.php
@@ -104,7 +104,7 @@ if ( null === $mem_conn ) {
 					<?php
 					printf(
 						/* translators: %1$s: Socket name, %2$s: Host field title, %3$s: Example socket path */
-						esc_html__( 'If you are using a %1$s socket, %2$s should be set to %3$s', 'litespeed-cache' ),
+						esc_html__( 'If you are using a %1$s socket, %2$s should be set to %3$s. Absolute paths must be used.', 'litespeed-cache' ),
 						'UNIX',
 						esc_html( Lang::title( $option_id ) ),
 						'<code>/path/to/memcached.sock</code>'


### PR DESCRIPTION
Validate OC host to be valid: IP, host name or absolute path in case of socket usage.
Works with address: `::1`

Ticket: [https://wordpress.org/support/topic/possible-bug-with-in-redis-path-in-litespeed-cache-wp-plugin/#post-18929290](https://wordpress.org/support/topic/possible-bug-with-in-redis-path-in-litespeed-cache-wp-plugin/#post-18929290)