### PR TITLE
fix(optm): css combine now matches placeholder link tag whitespace

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -259,6 +259,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 7.8.1 - Apr 1 2026 =
 * **CDN** Fixed Cloudflare API key type detection for the compatibility w/ the new key format.
+* **Page Optimize** Fixed CSS Combine serving unstyled pages when the placeholder link tag uses default WordPress whitespace. (#999)
 
 = 7.8.0.1 - Mar 17 2026 =
 * **Object Cache** Improved Object Cache resilience: auto disable when connection fails, network subsites fallback to database, and dropped TTL setting to respect never-expired transients.

--- a/src/optimize.cls.php
+++ b/src/optimize.cls.php
@@ -20,7 +20,7 @@ class Optimize extends Base {
 
 	const ITEM_TIMESTAMP_PURGE_CSS = 'timestamp_purge_css';
 
-	const DUMMY_CSS_REGEX = "#<link [ \w='\"/]*id=['\"]litespeed-cache-dummy-css['\"] href=['\"].+assets/css/litespeed-dummy\.css[?\w.=-]*['\"][ \w='\"/]*>#isU";
+	const DUMMY_CSS_REGEX = "#<link [ \w='\"/]*id=['\"]litespeed-cache-dummy-css['\"][ \w='\"/]*href=['\"].+assets/css/litespeed-dummy\.css[?\w.=-]*['\"][ \w='\"/]*>#isU";
 
 	private $content;
 	private $content_ori;
@@ -225,7 +225,7 @@ class Optimize extends Base {
 	public function finalize( $content ) {
 		$content = $this->_finalize($content);
 		// Fallback to replace dummy css placeholder
-		if (false !== preg_match(self::DUMMY_CSS_REGEX, $content)) {
+		if (1 === preg_match(self::DUMMY_CSS_REGEX, $content)) {
 			self::debug('Fallback to drop dummy CSS');
 			$content = preg_replace( self::DUMMY_CSS_REGEX, '', $content );
 		}
@@ -500,7 +500,7 @@ class Optimize extends Base {
 				$this->content = str_replace('</head>', $this->html_head . '</head>', $this->content);
 			} else {
 				// Put header content to dummy css position
-				if (false !== preg_match(self::DUMMY_CSS_REGEX, $this->content)) {
+				if (1 === preg_match(self::DUMMY_CSS_REGEX, $this->content)) {
 					self::debug('Put optm data to dummy css location');
 					$this->content = preg_replace( self::DUMMY_CSS_REGEX, $this->html_head, $this->content );
 				}


### PR DESCRIPTION
## Summary

CSS Combine could serve a fully unstyled page when the placeholder link tag used anything other than a single literal space between the `id` and `href` attributes (which is the default WordPress render for `wp_print_styles`). The bug came from two compounding defects in `src/optimize.cls.php`: a too-strict regex and a guard that treated a no-match as success.

Fixes #999

## Changes

### `src/optimize.cls.php` — `DUMMY_CSS_REGEX`

**Before:**
```php
const DUMMY_CSS_REGEX = "#<link [ \w='\"/]*id=['\"]litespeed-cache-dummy-css['\"] href=['\"].+assets/css/litespeed-dummy\.css[?\w.=-]*['\"][ \w='\"/]*>#isU";
```

**After:**
```php
const DUMMY_CSS_REGEX = "#<link [ \w='\"/]*id=['\"]litespeed-cache-dummy-css['\"][ \w='\"/]*href=['\"].+assets/css/litespeed-dummy\.css[?\w.=-]*['\"][ \w='\"/]*>#isU";
```

**Why:** the literal single space between the id value and `href=` is the gap that fails on WordPress's default two-space padding. Reusing the existing `[ \w='\"/]*` character class keeps the pattern consistent and matches one, two, or more spaces (matches the pattern both maintainer and reporter agreed on in the issue thread).

### `src/optimize.cls.php` — both `preg_match` guards

**Before:**
```php
// site 1: line 503
if (false !== preg_match(self::DUMMY_CSS_REGEX, $this->content)) {

// site 2: line 228
if (false !== preg_match(self::DUMMY_CSS_REGEX, $content)) {
```

**After:**
```php
if (1 === preg_match(self::DUMMY_CSS_REGEX, $this->content)) {
if (1 === preg_match(self::DUMMY_CSS_REGEX, $content)) {
```

**Why:** `preg_match()` returns `0` on no-match and `false` only on error. The old `false !==` check was true on `0`, so when the regex failed to match the code entered the "matched" branch, ran a no-op `preg_replace`, and the `elseif`/`else` fallbacks (meta charset / head insertion) never ran. The combined CSS was silently dropped. `1 ===` makes no-match correctly fall through. This is the real safety net for any future markup variation that fails the regex.

### `readme.txt`

Added a `* **Page Optimize**` bullet to the 7.8.1 changelog referencing #999.

## Testing

**Test 1: original repro on stock WP 6.0.x**
1. Enable **Page Optimization → CSS Combine**.
2. Confirm the placeholder link tag has two spaces between `id='…'` and `href='…'` in the raw HTML.
3. Load a cacheable front-end page and view source.
4. Result: combined CSS link present, placeholder gone, page styled.

**Test 2: whitespace variants**
1. With CSS Combine enabled, load pages on a stock install.
2. Result: placeholder replaced regardless of one, two, or more spaces between `id` and `href`.

**Test 3: guard fallback (synthetic non-match)**
1. Inject a `data-*` attribute between `id` and `href` via a `style_loader_tag` filter (edge case the char class still does not cover).
2. With CSS Combine enabled, purge cache, load a page.
3. Result: combined CSS injected after `<meta charset>` (debug log "Put optm data to be after <meta charset>") instead of being silently dropped.

**Test 4: PHPCS**
1. `composer sniff-check` and `npm run format-check` pass on changed files. The only failure in the repo is pre-existing and unrelated, in `src/cdn/cloudflare.cls.php` lines 249 and 277.
