### PR TITLE
Fix ESI nonce generation for actions with custom nonce lifetimes.

### DIFF
--- a/litespeed-cache.php
+++ b/litespeed-cache.php
@@ -184,9 +184,35 @@ if ( ! function_exists( 'litespeed_define_nonce_func' ) ) {
 			}
 
 			$token = wp_get_session_token();
-			$i     = wp_nonce_tick();
+			$i     = wp_nonce_tick_litespeed_esi( $action );
 
 			return substr( wp_hash( $i . '|' . $action . '|' . $uid . '|' . $token, 'nonce' ), -12, 10 );
+		}
+
+		/**
+		 * Gets the nonce tick for the given action.
+		 *
+		 * WordPress 6.1 added the nonce action parameter to wp_nonce_tick(), allowing
+		 * plugins to customize nonce lifetimes per action via the nonce_life filter.
+		 * Use the action-aware call when available so ESI-generated nonces match the
+		 * values that wp_verify_nonce()/check_ajax_referer() expect.
+		 *
+		 * @param mixed $action Action name or -1.
+		 * @return float
+		 */
+		function wp_nonce_tick_litespeed_esi( $action = -1 ) {
+			static $wp_nonce_tick_accepts_action = null;
+
+			if ( null === $wp_nonce_tick_accepts_action ) {
+				$reflection                   = new \ReflectionFunction( 'wp_nonce_tick' );
+				$wp_nonce_tick_accepts_action = $reflection->getNumberOfParameters() > 0;
+			}
+
+			if ( $wp_nonce_tick_accepts_action ) {
+				return wp_nonce_tick( $action );
+			}
+
+			return wp_nonce_tick();
 		}
 	}
 }

--- a/src/esi.cls.php
+++ b/src/esi.cls.php
@@ -866,8 +866,8 @@ class ESI extends Root {
 
 		self::debug('[ESI] load_nonce_block [action] ' . $action);
 
-		// set nonce TTL to half day
-		Control::set_custom_ttl(43200);
+		// Set the nonce block TTL to the current nonce tick length.
+		Control::set_custom_ttl($this->_nonce_block_ttl($action));
 
 		if (Router::is_logged_in()) {
 			Control::set_private();
@@ -878,6 +878,48 @@ class ESI extends Root {
 		} else {
 			echo wp_create_nonce($action);
 		}
+	}
+
+	/**
+	 * Gets the TTL for an ESI nonce block.
+	 *
+	 * WordPress nonces are based on ticks of nonce_life / 2. Respect the effective
+	 * nonce lifetime for the specific action so ESI nonce fragments do not outlive
+	 * shorter custom nonce windows.
+	 *
+	 * @access private
+	 * @param mixed $action Action name or -1.
+	 * @return int
+	 */
+	private function _nonce_block_ttl( $action ) {
+		if ($this->_wp_nonce_tick_accepts_action()) {
+			$lifespan = (int) apply_filters('nonce_life', DAY_IN_SECONDS, $action);
+		} else {
+			$lifespan = (int) apply_filters('nonce_life', DAY_IN_SECONDS);
+		}
+
+		if ($lifespan <= 0) {
+			$lifespan = DAY_IN_SECONDS;
+		}
+
+		return max(1, (int) ceil($lifespan / 2));
+	}
+
+	/**
+	 * Checks whether wp_nonce_tick() supports the nonce action parameter.
+	 *
+	 * @access private
+	 * @return bool
+	 */
+	private function _wp_nonce_tick_accepts_action() {
+		static $wp_nonce_tick_accepts_action = null;
+
+		if (null === $wp_nonce_tick_accepts_action) {
+			$reflection                   = new \ReflectionFunction('wp_nonce_tick');
+			$wp_nonce_tick_accepts_action = $reflection->getNumberOfParameters() > 0;
+		}
+
+		return $wp_nonce_tick_accepts_action;
 	}
 
 	/**


### PR DESCRIPTION
WordPress 6.1 allows wp_nonce_tick() to receive the nonce action so plugins can customize nonce lifetime per action via nonce_life. LiteSpeed’s ESI nonce generator was calling wp_nonce_tick() without the action, so ESI-generated nonces could differ from the values later expected by wp_verify_nonce() / check_ajax_referer(). This broke plugins such as Gravity Forms, which sets a custom 3-day lifetime for gform_ajax_submission.

This change makes ESI nonce generation action-aware where supported and sets the ESI nonce fragment TTL based on the effective action-specific nonce tick length.