### PR TITLE
ESI: prevent failed silent blocks (nonces) from injecting cache comments into inline JS

### DIFF
--- a/src/esi.cls.php
+++ b/src/esi.cls.php
@@ -614,6 +614,22 @@ class ESI extends Root {
 	 * @access public
 	 */
 	public function load_esi_block() {
+		$params = $this->_parse_esi_param();
+
+		/**
+		 * Silent ESI blocks (e.g. nonces, which are injected directly into inline
+		 * JavaScript/JSON) must never emit the running-info HTML comment. Set the
+		 * silence flag before the _hash validation below so that a failed or stale
+		 * block degrades to an empty string instead of corrupting the inline JS it
+		 * is embedded in.
+		 *
+		 * The params are only read here to decide comment suppression; the block
+		 * itself is still not executed until the _hash validation passes.
+		 */
+		if (!empty($params['_ls_silence'])) {
+			!defined('LSCACHE_ESI_SILENCE') && define('LSCACHE_ESI_SILENCE', true);
+		}
+
 		/**
 		 * Validate if is a legal ESI req
 		 *
@@ -624,8 +640,6 @@ class ESI extends Root {
 			return;
 		}
 
-		$params = $this->_parse_esi_param();
-
 		if (defined('LSCWP_LOG')) {
 			$logInfo = '[ESI] ⭕ ';
 			if (!empty($params[self::PARAM_NAME])) {
@@ -633,10 +647,6 @@ class ESI extends Root {
 			}
 			$logInfo .= ' [ID] ' . LSCACHE_IS_ESI;
 			self::debug($logInfo);
-		}
-
-		if (!empty($params['_ls_silence'])) {
-			!defined('LSCACHE_ESI_SILENCE') && define('LSCACHE_ESI_SILENCE', true);
 		}
 
 		/**


### PR DESCRIPTION
Fixes #1007 — see [litespeedtech/lscache_wp#1007](https://github.com/litespeedtech/lscache_wp/issues/1007) for the full analysis and reproduction.

## Problem

Silent ESI blocks (e.g. nonces) are injected directly into inline JavaScript/JSON. When such a block fails `_hash` validation in `load_esi_block()`, the method returns **before** `LSCACHE_ESI_SILENCE` is defined. As a result:

1. The block body is never generated (no nonce is output), and
2. The `<!-- Block cached by LiteSpeed Cache x.x.x on ... -->` running-info comment is **not** suppressed.

The ESI block then resolves to just that HTML comment, which gets injected where the nonce string was expected. Inside inline JS/JSON this produces a fatal `SyntaxError`. In our case it broke **all Gravity Forms for logged-out visitors**, because the comment landed inside the inline `gform_theme_config` object:

```js
var gform_theme_config = { ... "ajax_submission_nonce":"
<!-- Block cached by LiteSpeed Cache 7.8.1 on 2026-06-25 18:32:02 -->", ... };
```

```
Uncaught SyntaxError: Invalid or unexpected token
Uncaught ReferenceError: gform_theme_config is not defined
```

Full analysis and reproduction in [#1007](https://github.com/litespeedtech/lscache_wp/issues/1007).

## Fix

Parse the ESI params and set `LSCACHE_ESI_SILENCE` for silent blocks **before** the `_hash` validation early-return, so a failed/stale silent block degrades to an empty string instead of emitting an HTML comment into inline JS.

## Why it's safe

- The untrusted params are read **only** to decide comment suppression. The block itself is still executed only after `_hash` validation passes, so the security boundary is unchanged.
- Behavior for non-silent blocks and for successful validations is identical.
- Worst case becomes a graceful empty value (e.g. `"nonce":""`) instead of a fatal `SyntaxError` that breaks every dependent script on the page.

## Changes

- `src/esi.cls.php` — in `load_esi_block()`, move silent-block detection (`LSCACHE_ESI_SILENCE`) ahead of the `_hash` validation.

## Related

- Issue: [litespeedtech/lscache_wp#1007](https://github.com/litespeedtech/lscache_wp/issues/1007)
