### PR TITLE
ESI: make the `private` control on nonce blocks login-aware to stop empty nonces on public pages

### DIFF
--- a/litespeed-cache.php
+++ b/litespeed-cache.php
@@ -160,6 +160,17 @@ if ( ! function_exists( 'litespeed_define_nonce_func' ) ) {
 			if ( ! defined( 'LITESPEED_DISABLE_ALL' ) || ! LITESPEED_DISABLE_ALL ) {
 				$control = \LiteSpeed\ESI::cls()->is_nonce_action( $action );
 				if ( null !== $control ) {
+					// The `private` cache control on a nonce ESI include only has a private cache
+					// scope for logged-in visitors. `load_nonce_block()` mirrors this by calling
+					// `Control::set_private()` only when `Router::is_logged_in()` is true. Forcing
+					// `private` on the include for guests routes the fragment into the private cache
+					// with no vary scope, so on the Private Cache TTL cycle it regenerates to an empty
+					// block on a publicly cached page. Drop `private` for guests so the two stay
+					// consistent and the nonce resolves through the shared public ESI path.
+					if ( false !== strpos( $control, 'private' ) && ! \LiteSpeed\Router::is_logged_in() ) {
+						$control = trim( preg_replace( '/\bprivate\b/', '', $control ) );
+					}
+
 					$params = array(
 						'action' => $action,
 					);


### PR DESCRIPTION
Fixes #1009

## Summary

When a nonce is registered with the `private` control (e.g. `my_nonce_action private`), the `wp_create_nonce()` override emits a private ESI include for every visitor. On a publicly cached page, that routes guest fragments into a private cache scope that does not exist for anonymous requests; they go empty on the Private Cache TTL cycle (~1800s by default).

Strip `private` from the nonce control at emission when `! Router::is_logged_in()`, using the same predicate `load_nonce_block()` already uses to decide privacy is only needed for logged-in users. Full root-cause analysis, impact, and rejected alternatives are in the linked issue.

## Changes

- `litespeed-cache.php` — in the `wp_create_nonce()` override, drop `private` from the control before calling `sub_esi_block()` for non-logged-in requests.

```php
if ( false !== strpos( $control, 'private' ) && ! \LiteSpeed\Router::is_logged_in() ) {
    $control = trim( preg_replace( '/\bprivate\b/', '', $control ) );
}
```

## Why emission (not resolve)

See the issue for the full walkthrough. In short: `load_nonce_block()` already skips `set_private()` for guests; guest privacy is set earlier via the include's `cache-control='private'` attribute and `_control=private` in the signed URL — both fixed only at emission. A resolve-side change would require altering generic `load_esi_block()` and still could not rewrite the attribute baked into cached page HTML.

## Safety / `_hash`

- Logged-in behavior is unchanged (`private` on the include; `load_nonce_block()` still privatizes at resolve).
- Guest nonces are uid `0` and shared across anonymous visitors — public ESI is correct.
- `_control` is signed and validated symmetrically: guests omit it; logged-in users keep `_control=private`.

## Test plan

- [ ] Public page with a `private`-registered nonce, logged out: include has no `cache-control='private'`; nonce stays populated past Private Cache TTL (> 1 hour).
- [ ] Same page, logged in: nonce still resolved privately (unchanged).
- [ ] `_hash` validates for both guest and logged-in includes after the control change.
