### PR TITLE
Add Gravity Forms ESI nonce detection

### DIFF
--- a/data/esi.nonces.txt
+++ b/data/esi.nonces.txt
@@ -98,3 +98,6 @@ wpda-*
 # Elementor
 elementor-pro-frontend
 elementor-conversion-center-click
+
+# Gavity Forms
+gfrom_*


### PR DESCRIPTION
Register Gravity Forms nonces for ESI support.

Topic: https://wordpress.org/support/topic/gravity-forms-file-upload-returns-403-after-cached-upload-token-expires