### PR TITLE
Fix: always restore error handler in object cache Redis _connect() (finally + \Throwable)

### DIFF
--- a/litespeed-cache.php
+++ b/litespeed-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name:       LiteSpeed Cache
  * Plugin URI:        https://www.litespeedtech.com/products/cache-plugins/wordpress-acceleration
  * Description:       High-performance page caching and site optimization from LiteSpeed
- * Version:           7.8.0.1
+ * Version:           7.8.1
  * Author:            LiteSpeed Technologies
  * Author URI:        https://www.litespeedtech.com
  * License:           GPLv3
@@ -35,7 +35,7 @@ if ( defined( 'LSCWP_V' ) ) {
 	return;
 }
 
-! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8.0.1' );
+! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8.1' );
 
 ! defined( 'LSCWP_CONTENT_DIR' ) && define( 'LSCWP_CONTENT_DIR', WP_CONTENT_DIR );
 ! defined( 'LSCWP_DIR' ) && define( 'LSCWP_DIR', __DIR__ . '/' ); // Full absolute path '/var/www/html/***/wp-content/plugins/litespeed-cache/' or MU

--- a/litespeed-cache.php
+++ b/litespeed-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name:       LiteSpeed Cache
  * Plugin URI:        https://www.litespeedtech.com/products/cache-plugins/wordpress-acceleration
  * Description:       High-performance page caching and site optimization from LiteSpeed
- * Version:           7.8
+ * Version:           7.8.0.1-rc1
  * Author:            LiteSpeed Technologies
  * Author URI:        https://www.litespeedtech.com
  * License:           GPLv3
@@ -35,7 +35,7 @@ if ( defined( 'LSCWP_V' ) ) {
 	return;
 }
 
-! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8' );
+! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8.0.1-rc1' );
 
 ! defined( 'LSCWP_CONTENT_DIR' ) && define( 'LSCWP_CONTENT_DIR', WP_CONTENT_DIR );
 ! defined( 'LSCWP_DIR' ) && define( 'LSCWP_DIR', __DIR__ . '/' ); // Full absolute path '/var/www/html/***/wp-content/plugins/litespeed-cache/' or MU

--- a/litespeed-cache.php
+++ b/litespeed-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name:       LiteSpeed Cache
  * Plugin URI:        https://www.litespeedtech.com/products/cache-plugins/wordpress-acceleration
  * Description:       High-performance page caching and site optimization from LiteSpeed
- * Version:           7.8.0.1-rc1
+ * Version:           7.8.0.1-rc2
  * Author:            LiteSpeed Technologies
  * Author URI:        https://www.litespeedtech.com
  * License:           GPLv3
@@ -35,7 +35,7 @@ if ( defined( 'LSCWP_V' ) ) {
 	return;
 }
 
-! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8.0.1-rc1' );
+! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8.0.1-rc2' );
 
 ! defined( 'LSCWP_CONTENT_DIR' ) && define( 'LSCWP_CONTENT_DIR', WP_CONTENT_DIR );
 ! defined( 'LSCWP_DIR' ) && define( 'LSCWP_DIR', __DIR__ . '/' ); // Full absolute path '/var/www/html/***/wp-content/plugins/litespeed-cache/' or MU

--- a/litespeed-cache.php
+++ b/litespeed-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name:       LiteSpeed Cache
  * Plugin URI:        https://www.litespeedtech.com/products/cache-plugins/wordpress-acceleration
  * Description:       High-performance page caching and site optimization from LiteSpeed
- * Version:           7.8.0.1-rc3
+ * Version:           7.8.0.1-rc4
  * Author:            LiteSpeed Technologies
  * Author URI:        https://www.litespeedtech.com
  * License:           GPLv3
@@ -35,7 +35,7 @@ if ( defined( 'LSCWP_V' ) ) {
 	return;
 }
 
-! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8.0.1-rc3' );
+! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8.0.1-rc4' );
 
 ! defined( 'LSCWP_CONTENT_DIR' ) && define( 'LSCWP_CONTENT_DIR', WP_CONTENT_DIR );
 ! defined( 'LSCWP_DIR' ) && define( 'LSCWP_DIR', __DIR__ . '/' ); // Full absolute path '/var/www/html/***/wp-content/plugins/litespeed-cache/' or MU

--- a/litespeed-cache.php
+++ b/litespeed-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name:       LiteSpeed Cache
  * Plugin URI:        https://www.litespeedtech.com/products/cache-plugins/wordpress-acceleration
  * Description:       High-performance page caching and site optimization from LiteSpeed
- * Version:           7.8.0.1-rc2
+ * Version:           7.8.0.1-rc3
  * Author:            LiteSpeed Technologies
  * Author URI:        https://www.litespeedtech.com
  * License:           GPLv3
@@ -35,7 +35,7 @@ if ( defined( 'LSCWP_V' ) ) {
 	return;
 }
 
-! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8.0.1-rc2' );
+! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8.0.1-rc3' );
 
 ! defined( 'LSCWP_CONTENT_DIR' ) && define( 'LSCWP_CONTENT_DIR', WP_CONTENT_DIR );
 ! defined( 'LSCWP_DIR' ) && define( 'LSCWP_DIR', __DIR__ . '/' ); // Full absolute path '/var/www/html/***/wp-content/plugins/litespeed-cache/' or MU

--- a/litespeed-cache.php
+++ b/litespeed-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name:       LiteSpeed Cache
  * Plugin URI:        https://www.litespeedtech.com/products/cache-plugins/wordpress-acceleration
  * Description:       High-performance page caching and site optimization from LiteSpeed
- * Version:           7.8.0.1-rc4
+ * Version:           7.8.0.1
  * Author:            LiteSpeed Technologies
  * Author URI:        https://www.litespeedtech.com
  * License:           GPLv3
@@ -35,7 +35,7 @@ if ( defined( 'LSCWP_V' ) ) {
 	return;
 }
 
-! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8.0.1-rc4' );
+! defined( 'LSCWP_V' ) && define( 'LSCWP_V', '7.8.0.1' );
 
 ! defined( 'LSCWP_CONTENT_DIR' ) && define( 'LSCWP_CONTENT_DIR', WP_CONTENT_DIR );
 ! defined( 'LSCWP_DIR' ) && define( 'LSCWP_DIR', __DIR__ . '/' ); // Full absolute path '/var/www/html/***/wp-content/plugins/litespeed-cache/' or MU

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: caching, optimize, performance, pagespeed, seo, image optimize, object cac
 Requires at least: 5.3
 Requires PHP: 7.2
 Tested up to: 6.9
-Stable tag: 7.8.0.1
+Stable tag: 7.8.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 
@@ -256,6 +256,9 @@ The vast majority of plugins and themes are compatible with LiteSpeed Cache. The
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/litespeed-cache)
 
 == Changelog ==
+
+= 7.8.1 - Apr 1 2026 =
+* **CDN** Fixed Cloudflare API key type detection for the compatibility w/ the new key format.
 
 = 7.8.0.1 - Mar 17 2026 =
 * **Object Cache** Improved Object Cache resilience: auto disable when connection fails, network subsites fallback to database, and dropped TTL setting to respect never-expired transients.

--- a/readme.txt
+++ b/readme.txt
@@ -257,6 +257,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= 7.8.0.1 - Mar 17 2026 =
+* **Object Cache** Improved Object Cache resilience: auto disable when connection fails, network subsites fallback to database, and dropped TTL setting to respect never-expired transients.
+
 = 7.8 - Mar 3 2026 =
 * **Cloud** Changed Health service to run asynchronously.
 * **Object Cache** Dropped `Store Transients` option. Transients now always use Object Cache when available, preventing potential database bloat from expired transients not being cleared. (ravanh)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: caching, optimize, performance, pagespeed, seo, image optimize, object cac
 Requires at least: 5.3
 Requires PHP: 7.2
 Tested up to: 6.9
-Stable tag: 7.8
+Stable tag: 7.8.0.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 

--- a/src/base.cls.php
+++ b/src/base.cls.php
@@ -181,7 +181,7 @@ class Base extends Root {
 	const O_OBJECT_KIND                  = 'object-kind';
 	const O_OBJECT_HOST                  = 'object-host';
 	const O_OBJECT_PORT                  = 'object-port';
-	const O_OBJECT_LIFE                  = 'object-life';
+	const O_OBJECT_LIFE                  = 'object-life'; // @deprecated Since v8.0. Will be removed in v8.5. TTL now follows WP API: expire=0 means no expiration.
 	const O_OBJECT_PERSISTENT            = 'object-persistent';
 	const O_OBJECT_ADMIN                 = 'object-admin';
 	const O_OBJECT_DB_ID                 = 'object-db_id';

--- a/src/cdn/cloudflare.cls.php
+++ b/src/cdn/cloudflare.cls.php
@@ -273,7 +273,12 @@ class Cloudflare extends Base {
 			}
 			$wp_args['body'] = $data;
 		}
-		$resp = wp_remote_request($url, $wp_args);
+		add_filter( 'http_api_curl', $fn = function ( $handle ) {
+			defined( 'CURLOPT_SSL_ENABLE_ALPN' ) && \curl_setopt( $handle, CURLOPT_SSL_ENABLE_ALPN, false );
+			return $handle;
+		}, 9999 );
+		$resp = wp_remote_request( $url, $wp_args );
+		remove_filter( 'http_api_curl', $fn, 9999 );
 		if (is_wp_error($resp)) {
 			Debug2::debug('[Cloudflare] error in response');
 			if ($show_msg) {

--- a/src/cdn/cloudflare.cls.php
+++ b/src/cdn/cloudflare.cls.php
@@ -244,17 +244,22 @@ class Cloudflare extends Base {
 	private function cloudflare_call( $url, $method = 'GET', $data = false, $show_msg = true ) {
 		Debug2::debug("[Cloudflare] cloudflare_call \t\t[URL] $url");
 
-		if (strlen($this->conf(self::O_CDN_CLOUDFLARE_KEY)) === 40) {
-			$headers = array(
-				'Content-Type'  => 'application/json',
-				'Authorization' => 'Bearer ' . $this->conf(self::O_CDN_CLOUDFLARE_KEY),
-			);
+		/**
+		 * Detect key type: Global API Key (37-char hex) vs API Token (Bearer)
+		 * @since 1.9.0
+		 */
+		$cf_key = $this->conf( self::O_CDN_CLOUDFLARE_KEY );
+		if ( strlen( $cf_key ) === 37 && preg_match( '/^[0-9a-f]+$/', $cf_key ) ) {
+			$headers = [
+				'Content-Type' => 'application/json',
+				'X-Auth-Email' => $this->conf( self::O_CDN_CLOUDFLARE_EMAIL ),
+				'X-Auth-Key'   => $cf_key,
+			];
 		} else {
-			$headers = array(
+			$headers = [
 				'Content-Type'  => 'application/json',
-				'X-Auth-Email' => $this->conf(self::O_CDN_CLOUDFLARE_EMAIL),
-				'X-Auth-Key'   => $this->conf(self::O_CDN_CLOUDFLARE_KEY),
-			);
+				'Authorization' => 'Bearer ' . $cf_key,
+			];
 		}
 
 		$wp_args = array(

--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -308,7 +308,7 @@ class Object_Cache extends Root {
 
 		// If OC not available, tell WP so transients fall back to wp_options
 		if ( ! $this->_cfg_enabled ) {
-			wp_using_ext_object_cache( false );
+			function_exists('wp_using_ext_object_cache') && wp_using_ext_object_cache( false );
 		}
 	}
 
@@ -574,7 +574,7 @@ class Object_Cache extends Root {
 			! defined( 'LITESPEED_OC_FAILURE' ) && define( 'LITESPEED_OC_FAILURE', true );
 
 			// Tell WP no external OC available, so transients fall back to wp_options table
-			wp_using_ext_object_cache( false );
+			function_exists('wp_using_ext_object_cache') && wp_using_ext_object_cache( false );
 
 			return false;
 		}

--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -306,9 +306,12 @@ class Object_Cache extends Root {
 			$this->_cfg_enabled = false;
 		}
 
-		// If OC not available, tell WP so transients fall back to wp_options
+		// If OC not available, mark failure so OC methods return false early.
+		// NOTE: Do NOT call wp_using_ext_object_cache(false) here — it causes
+		// "Cannot redeclare wp_cache_init()" fatal on multisite (second call
+		// to wp_start_object_cache() would load cache.php again).
 		if ( ! $this->_cfg_enabled ) {
-			function_exists('wp_using_ext_object_cache') && wp_using_ext_object_cache( false );
+			! defined( 'LITESPEED_OC_FAILURE' ) && define( 'LITESPEED_OC_FAILURE', true );
 		}
 	}
 
@@ -573,8 +576,7 @@ class Object_Cache extends Root {
 			$this->_cfg_enabled = false;
 			! defined( 'LITESPEED_OC_FAILURE' ) && define( 'LITESPEED_OC_FAILURE', true );
 
-			// Tell WP no external OC available, so transients fall back to wp_options table
-			function_exists('wp_using_ext_object_cache') && wp_using_ext_object_cache( false );
+			// NOTE: Do NOT call wp_using_ext_object_cache(false) — causes fatal on multisite.
 
 			return false;
 		}

--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -305,6 +305,11 @@ class Object_Cache extends Root {
 		} else {
 			$this->_cfg_enabled = false;
 		}
+
+		// If OC not available, tell WP so transients fall back to wp_options
+		if ( ! $this->_cfg_enabled ) {
+			wp_using_ext_object_cache( false );
+		}
 	}
 
 	/**
@@ -567,7 +572,10 @@ class Object_Cache extends Root {
 			$this->_conn        = null;
 			$this->_cfg_enabled = false;
 			! defined( 'LITESPEED_OC_FAILURE' ) && define( 'LITESPEED_OC_FAILURE', true );
-			// error_log( 'Object: false!' );
+
+			// Tell WP no external OC available, so transients fall back to wp_options table
+			wp_using_ext_object_cache( false );
+
 			return false;
 		}
 
@@ -675,11 +683,14 @@ class Object_Cache extends Root {
 			return false;
 		}
 
-		$ttl = $expire ? $expire : $this->_cfg_life;
+		// Per WP Object Cache API, expire=0 means "no expiration".
+		// Key eviction is handled by the cache backend (Redis maxmemory / Memcached LRU).
+		$ttl = (int) $expire;
 
 		if ( 'Redis' === $this->_oc_driver ) {
 			try {
-				$res = $this->_conn->setEx( $key, $ttl, $data );
+				$options = ( $ttl > 0 ) ? [ 'ex' => $ttl ] : [];
+				$res     = $this->_conn->set( $key, $data, $options );
 			} catch ( \RedisException $ex ) {
 				$res = false;
 				$msg = sprintf( __( 'Redis encountered a fatal error: %1$s (code: %2$d)', 'litespeed-cache' ), $ex->getMessage(), $ex->getCode() );

--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -514,7 +514,10 @@ class Object_Cache extends Root {
 				}
 
 				if ( $this->_cfg_db ) {
-					$this->_conn->select( $this->_cfg_db );
+					if ( ! $this->_conn->select( $this->_cfg_db ) ) {
+						$this->debug_oc( 'Database ID is invalid' );
+						$failed = true;
+					}
 				}
 
 				$res = $this->_conn->rawCommand('PING');

--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -576,7 +576,14 @@ class Object_Cache extends Root {
 			$this->_cfg_enabled = false;
 			! defined( 'LITESPEED_OC_FAILURE' ) && define( 'LITESPEED_OC_FAILURE', true );
 
-			// NOTE: Do NOT call wp_using_ext_object_cache(false) — causes fatal on multisite.
+			// Disable ext OC flag so WP transients fall back to wp_options table.
+			// After muplugins_loaded, all wp_start_object_cache() calls are done — safe to call directly.
+			// Before that (early bootstrap), defer via hook to avoid multisite "Cannot redeclare" fatal.
+			if ( function_exists( 'did_action' ) && did_action( 'muplugins_loaded' ) ) {
+				litespeed_oc_disable_ext_cache();
+			} elseif ( function_exists( 'add_action' ) ) {
+				add_action( 'muplugins_loaded', 'litespeed_oc_disable_ext_cache', -999 );
+			}
 
 			return false;
 		}

--- a/src/object-cache.cls.php
+++ b/src/object-cache.cls.php
@@ -526,14 +526,12 @@ class Object_Cache extends Root {
 					$this->debug_oc( 'Redis resp is wrong: ' . $res );
 					$failed = true;
 				}
-			} catch ( \Exception $e ) {
-				$this->debug_oc( 'Redis connect exception: ' . $e->getMessage() );
-				$failed = true;
-			} catch ( \ErrorException $e ) {
+			} catch ( \Throwable $e ) {
 				$this->debug_oc( 'Redis connect error: ' . $e->getMessage() );
 				$failed = true;
+			} finally {
+				restore_error_handler();
 			}
-			restore_error_handler();
 		} else {
 			// Connect to Memcached.
 			if ( $this->_cfg_persistent ) {

--- a/src/object.lib.php
+++ b/src/object.lib.php
@@ -42,6 +42,30 @@ require_once __DIR__ . '/object-cache-wp.cls.php';
 function wp_cache_init() {
 	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	$GLOBALS['wp_object_cache'] = WP_Object_Cache::get_instance();
+
+	// If OC backend is unavailable, tell WP so transients fall back to wp_options.
+	// IMPORTANT: Cannot call wp_using_ext_object_cache(false) here directly — on
+	// multisite, wp_start_object_cache() is called a second time (ms-settings.php)
+	// and would try to load cache.php, causing "Cannot redeclare wp_cache_init()".
+	// Defer until after all wp_start_object_cache() calls are done.
+	if ( defined( 'LITESPEED_OC_FAILURE' ) ) {
+		add_action( 'muplugins_loaded', 'litespeed_oc_disable_ext_cache', -999 );
+	}
+}
+
+if ( ! function_exists( 'litespeed_oc_disable_ext_cache' ) ) {
+/**
+ * Deferred callback to disable external object cache flag.
+ *
+ * Called after all wp_start_object_cache() calls are done, so WP's own
+ * set_transient/get_transient will use wp_options table instead of OC.
+ *
+ * @since 7.8.0.1
+ * @access public
+ */
+function litespeed_oc_disable_ext_cache() {
+	wp_using_ext_object_cache( false );
+}
 }
 
 /**

--- a/src/object.lib.php
+++ b/src/object.lib.php
@@ -27,6 +27,21 @@ function litespeed_exception_handler( $errno, $errstr, $errfile, $errline ) {
 }
 }
 
+if ( ! function_exists( 'litespeed_oc_disable_ext_cache' ) ) {
+/**
+ * Disable external object cache flag.
+ *
+ * When called, WP's own set_transient/get_transient will use wp_options
+ * table instead of the (unavailable) OC backend.
+ *
+ * @since 7.8.0.1
+ * @access public
+ */
+function litespeed_oc_disable_ext_cache() {
+	wp_using_ext_object_cache( false );
+}
+}
+
 require_once __DIR__ . '/object-cache.cls.php';
 require_once __DIR__ . '/object-cache-wp.cls.php';
 
@@ -51,21 +66,6 @@ function wp_cache_init() {
 	if ( defined( 'LITESPEED_OC_FAILURE' ) ) {
 		add_action( 'muplugins_loaded', 'litespeed_oc_disable_ext_cache', -999 );
 	}
-}
-
-if ( ! function_exists( 'litespeed_oc_disable_ext_cache' ) ) {
-/**
- * Deferred callback to disable external object cache flag.
- *
- * Called after all wp_start_object_cache() calls are done, so WP's own
- * set_transient/get_transient will use wp_options table instead of OC.
- *
- * @since 7.8.0.1
- * @access public
- */
-function litespeed_oc_disable_ext_cache() {
-	wp_using_ext_object_cache( false );
-}
 }
 
 /**

--- a/tpl/toolbox/beta_test.tpl.php
+++ b/tpl/toolbox/beta_test.tpl.php
@@ -14,6 +14,7 @@ defined( 'WPINC' ) || exit;
 
 // List of available public versions
 $v_list = array(
+	'7.8.0.1',
 	'7.8',
 	'7.7',
 	'7.6.2',

--- a/tpl/toolbox/beta_test.tpl.php
+++ b/tpl/toolbox/beta_test.tpl.php
@@ -14,6 +14,7 @@ defined( 'WPINC' ) || exit;
 
 // List of available public versions
 $v_list = array(
+	'7.8.1',
 	'7.8.0.1',
 	'7.8',
 	'7.7',


### PR DESCRIPTION
## Problem

`Object_Cache::_connect()` registers `set_error_handler( 'litespeed_exception_handler' )` around the Redis connection, but only catches `\Exception` / `\ErrorException` and calls `restore_error_handler()` after the `try`/`catch`. If a `\Error` (e.g. a `TypeError`/`ValueError` on PHP 8.x) escapes the connect path, both `catch` blocks are skipped, `restore_error_handler()` never runs, and `litespeed_exception_handler` stays registered for the rest of the request.

Since that handler rethrows every PHP error as an `ErrorException`, any later unrelated PHP 8.1+ deprecation — e.g. Gravity Forms `dirname(null)` or Wordfence `strrpos(null)` — becomes a fatal `Uncaught ErrorException`, white-screening the whole site **even with `WP_DEBUG` off**. The stack trace points at the *other* plugin, so it's very hard to trace back to the object cache.

Also, the `catch ( \ErrorException $e )` after `catch ( \Exception $e )` was unreachable — `\ErrorException` extends `\Exception`.

## Fix

Catch `\Throwable` (covers `\Error` too, and folds in the previously-unreachable `\ErrorException` branch) and move `restore_error_handler()` into a `finally` so the handler is always restored.

## Notes

- `\Throwable` / `finally` are PHP 7.0+, within the plugin's `Requires PHP: 7.2`.
- Behaviour on a genuine connection failure is unchanged: `$failed = true` and fall back as before.

Fixes #1013
