### PR TITLE
3rd: Disable LiteSpeed Cache in the Cornerstone editor (like Elementor)

### DIFF
--- a/thirdparty/cornerstone.cls.php
+++ b/thirdparty/cornerstone.cls.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * The Third Party integration with Themeco Cornerstone (Pro theme / standalone).
+ *
+ * Detects the Cornerstone editor and disables LiteSpeed Cache features that
+ * interfere with live editing. Cornerstone runs on a frontend app path
+ * (default /cornerstone), so ESI would otherwise rewrite wp_create_nonce( 'wp_rest' )
+ * into an HTML comment inside wp_localize_script / csAppConfig JSON and break the builder.
+ *
+ * @since      7.9
+ * @package    LiteSpeed
+ * @subpackage LiteSpeed_Cache/thirdparty
+ */
+
+namespace LiteSpeed\Thirdparty;
+
+defined( 'WPINC' ) || exit();
+
+/**
+ * Handles Cornerstone compatibility.
+ */
+class Cornerstone {
+
+	/**
+	 * Preload hooks and disable caching features during Cornerstone editor flows.
+	 *
+	 * This method only inspects request/server values to detect editor context.
+	 * No privileged actions are performed here, so nonce verification is not required.
+	 *
+	 * @since 7.9
+	 * @return void
+	 */
+	public static function preload() {
+		if ( ! defined( 'CS_VERSION' ) ) {
+			return;
+		}
+
+		$slug = self::app_slug();
+		if ( '' === $slug ) {
+			return;
+		}
+
+		// Cornerstone editor bootstrap (frontend app route, not wp-admin).
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( self::path_has_app_slug( $request_uri, $slug ) ) {
+			do_action( 'litespeed_disable_all', 'cornerstone edit mode' );
+			return;
+		}
+
+		// AJAX/REST from the editor: Referer is the Cornerstone app URL.
+		$http_referer = isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( self::path_has_app_slug( $http_referer, $slug ) ) {
+			do_action( 'litespeed_disable_all', 'cornerstone edit mode in HTTP_REFERER' );
+		}
+	}
+
+	/**
+	 * Resolve Cornerstone's app path slug (default "cornerstone", or custom_app_slug).
+	 *
+	 * @since 7.9
+	 * @return string
+	 */
+	private static function app_slug() {
+		$settings = get_option( 'cornerstone_settings', array() );
+		if ( is_array( $settings ) && ! empty( $settings['custom_app_slug'] ) ) {
+			return sanitize_title_with_dashes( $settings['custom_app_slug'] );
+		}
+
+		/**
+		 * Allow themes/plugins that filter the default slug before settings exist.
+		 *
+		 * @see apply_filters( 'cs_app_slug', ... ) in Cornerstone Settings.
+		 */
+		$slug = apply_filters( 'cs_app_slug', 'cornerstone' );
+		return is_string( $slug ) ? sanitize_title_with_dashes( $slug ) : 'cornerstone';
+	}
+
+	/**
+	 * Whether a URI or full URL contains the Cornerstone app path as a segment.
+	 *
+	 * @since 7.9
+	 * @param string $uri  Request URI or referer URL.
+	 * @param string $slug App slug (e.g. cornerstone).
+	 * @return bool
+	 */
+	private static function path_has_app_slug( $uri, $slug ) {
+		if ( '' === $uri || '' === $slug ) {
+			return false;
+		}
+
+		$path = wp_parse_url( $uri, PHP_URL_PATH );
+		if ( ! is_string( $path ) || '' === $path ) {
+			$path = $uri;
+		}
+
+		return (bool) preg_match( '#(?:^|/)' . preg_quote( $slug, '#' ) . '(?:/|$)#', $path );
+	}
+}

--- a/thirdparty/entry.inc.php
+++ b/thirdparty/entry.inc.php
@@ -50,6 +50,7 @@ add_action('litespeed_init', 'LiteSpeed\Thirdparty\WooCommerce::preload');
 add_action('litespeed_init', 'LiteSpeed\Thirdparty\NextGenGallery::preload');
 add_action('litespeed_init', 'LiteSpeed\Thirdparty\AMP::preload');
 add_action('litespeed_init', 'LiteSpeed\Thirdparty\Elementor::preload');
+add_action('litespeed_init', 'LiteSpeed\Thirdparty\Cornerstone::preload');
 add_action('litespeed_init', 'LiteSpeed\Thirdparty\Gravity_Forms::preload');
 add_action('litespeed_init', 'LiteSpeed\Thirdparty\Perfmatters::preload');
 add_action('litespeed_init', 'LiteSpeed\Thirdparty\Rank_Math::preload');


### PR DESCRIPTION
## Summary

- Adds a Cornerstone third-party integration that calls `litespeed_disable_all` on the editor app path (default `/cornerstone`, or a custom `custom_app_slug`) and on requests whose `HTTP_REFERER` is that app — the same approach used for Elementor.
- Fixes ESI rewriting `wp_create_nonce( 'wp_rest' )` into an HTML comment inside `wp_localize_script` / `csAppConfig` JSON when the builder loads on the frontend, which causes `SyntaxError: Invalid or unexpected token` and dumps the builder config as plain text.

Cornerstone (Pro theme / standalone) defines `CS_VERSION` and serves the editor outside `wp-admin`, so LiteSpeed’s admin bypass does not apply and the predefined `wp_rest` ESI nonce corrupts the page.

## Test plan

- [ ] On a site with LiteSpeed Cache + ESI enabled and Pro/Cornerstone active, open `/cornerstone/` and confirm the builder UI loads (no wall of text / console SyntaxErrors on `wp-api-fetch` / `cs-app-js-extra`).
- [ ] Confirm view-source shows a normal REST nonce string (not `<!-- Block uncached by LiteSpeed Cache -->` or `[an error occurred while processing this directive]`).
- [ ] With a custom Cornerstone Path set, confirm the editor still loads and LiteSpeed stays disabled on that path.
- [ ] Confirm a normal frontend page still caches / uses ESI as before when not editing in Cornerstone.


Made with [Cursor](https://cursor.com)