### PR TITLE
fix(cli): pass action parameter in Purge send_request

### DIFF
--- a/cli/purge.cls.php
+++ b/cli/purge.cls.php
@@ -55,17 +55,18 @@ class Purge {
 	 */
 	private function send_request( $action, $extra = array() ) {
 		$data = array(
+			'action'       => 'litespeed_ajax',
 			Router::ACTION => $action,
-			Router::NONCE => wp_create_nonce( $action ),
+			Router::NONCE  => wp_create_nonce( $action ),
 		);
 		if ( ! empty( $extra ) ) {
 			$data = array_merge( $data, $extra );
 		}
 
-		$url = admin_url( 'admin-ajax.php' );
+		$url = add_query_arg( $data, admin_url( 'admin-ajax.php' ) );
 		WP_CLI::debug( 'URL is ' . $url );
 
-		$out = WP_CLI\Utils\http_request( 'GET', $url, $data );
+		$out = WP_CLI\Utils\http_request( 'GET', $url );
 		return $out;
 	}
 
@@ -114,7 +115,7 @@ class Purge {
 		if ( ! is_numeric( $blogid ) ) {
 			$error = WP_CLI::colorize( '%RError: invalid blog id entered.%n' );
 			WP_CLI::line( $error );
-			$this->network_list( $args );
+			$this->network_list();
 			return;
 		}
 
@@ -122,7 +123,7 @@ class Purge {
 		if ( false === $site ) {
 			$error = WP_CLI::colorize( '%RError: invalid blog id entered.%n' );
 			WP_CLI::line( $error );
-			$this->network_list( $args );
+			$this->network_list();
 			return;
 		}
 
@@ -175,9 +176,10 @@ class Purge {
 			}
 		}
 
+		$url = add_query_arg( $data, $url );
 		WP_CLI::debug( 'URL is ' . $url );
 
-		$purge_ret = WP_CLI\Utils\http_request( 'GET', $url, $data );
+		$purge_ret = WP_CLI\Utils\http_request( 'GET', $url );
 		if ( $purge_ret->success ) {
 			WP_CLI::success( __( 'Purged the URL!', 'litespeed-cache' ) );
 		} else {


### PR DESCRIPTION
## Summary
WP-CLI purge commands fail with HTTP 400 because send_request does not include the required action parameter when making requests to admin-ajax.php. This change adds `'action' => 'litespeed_ajax'` and uses `add_query_arg()` to format query parameters into the GET request URL string.

Fixes #963

## Changes
### `cli/purge.cls.php`
**Before:**
```php
	private function send_request( $action, $extra = array() ) {
		$data = array(
			Router::ACTION => $action,
			Router::NONCE => wp_create_nonce( $action ),
		);
		if ( ! empty( $extra ) ) {
			$data = array_merge( $data, $extra );
		}

		$url = admin_url( 'admin-ajax.php' );
		WP_CLI::debug( 'URL is ' . $url );

		$out = WP_CLI\Utils\http_request( 'GET', $url, $data );
		return $out;
	}
```
**After:**
```php
	private function send_request( $action, $extra = array() ) {
		$data = array(
			'action'       => 'litespeed_ajax',
			Router::ACTION => $action,
			Router::NONCE  => wp_create_nonce( $action ),
		);
		if ( ! empty( $extra ) ) {
			$data = array_merge( $data, $extra );
		}

		$url = add_query_arg( $data, admin_url( 'admin-ajax.php' ) );
		WP_CLI::debug( 'URL is ' . $url );

		$out = WP_CLI\Utils\http_request( 'GET', $url );
		return $out;
	}
```
**Why:** WordPress `admin-ajax.php` requires an action parameter in `$_REQUEST`. Passing `'action' => 'litespeed_ajax'` and building query arguments with `add_query_arg()` ensures parameters are properly passed on GET requests.

## Testing
**Test 1: WP-CLI Purge All**
1. Run `wp litespeed-purge all`
Result: works as expected, returns success status.
