### PR TITLE
fix(optimize): replace load event listeners in JS Delay mode

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -259,6 +259,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 8.0 - Coming soon 2026 =
 * 🌱**OptiMax** OptiMax to maximize the page score.
+* **Optimize** Fixed JS Delay mode not executing `load` event listeners. (#629)
 
 = 7.9 - Aug 5 2026 =
 * **Cloud** Changed Health service to run asynchronously, resuming through WP cron when the cloud defers the request.

--- a/src/optimize.cls.php
+++ b/src/optimize.cls.php
@@ -90,8 +90,7 @@ class Optimize extends Base {
 				'litespeed_optm_cssjs',
 				function ( $con, $file_type ) {
 					if ($file_type == 'js') {
-						$con = str_replace('DOMContentLoaded', 'DOMContentLiteSpeedLoaded', $con);
-						// $con = str_replace( 'addEventListener("load"', 'addEventListener("litespeedLoad"', $con );
+						$con = $this->_replace_js_events( $con );
 					}
 					return $con;
 				},
@@ -1005,14 +1004,30 @@ class Optimize extends Base {
 		if ($this->cfg_js_defer === 2) {
 			// Drop type attribute from $attrs
 			$attrs = Utility::remove_attr( $attrs, 'type' );
-			// Replace DOMContentLoaded
-			$con = str_replace('DOMContentLoaded', 'DOMContentLiteSpeedLoaded', $con);
+			// Replace DOMContentLoaded and load event listeners
+			$con = $this->_replace_js_events( $con );
 			return '<script' . $attrs . ' type="litespeed/javascript">' . $con . '</script>';
 			// return '<script' . $attrs . ' type="litespeed/javascript" src="data:text/javascript;base64,' . base64_encode( $con ) . '"></script>';
 			// return '<script' . $attrs . ' type="litespeed/javascript">' . $con . '</script>';
 		}
 
 		return '<script' . $attrs . ' src="data:text/javascript;base64,' . base64_encode($con) . '" defer></script>';
+	}
+
+	/**
+	 * Replace JS DOMContentLoaded and load event listeners for JS Delay mode
+	 *
+	 * @since  7.0
+	 */
+	private function _replace_js_events( $con ) {
+		if ( empty( $con ) || ! is_string( $con ) ) {
+			return $con;
+		}
+
+		$con = str_replace( 'DOMContentLoaded', 'DOMContentLiteSpeedLoaded', $con );
+		$con = preg_replace( '/(?<!\.)\b(window\.|document\.)?addEventListener\(\s*([\'"])load\2/', '$1addEventListener($2DOMContentLiteSpeedLoaded$2', $con );
+		$con = preg_replace( '/((?:\$|jQuery)\(\s*(?:window|document)\s*\)\s*\.on\(\s*)([\'"])load(?:\.[\w-]+)?\2/', '$1$2DOMContentLiteSpeedLoaded$2', $con );
+		return $con;
 	}
 
 	/**

--- a/src/optimize.cls.php
+++ b/src/optimize.cls.php
@@ -1017,7 +1017,7 @@ class Optimize extends Base {
 	/**
 	 * Replace JS DOMContentLoaded and load event listeners for JS Delay mode
 	 *
-	 * @since  7.0
+	 * @since  8.0
 	 */
 	private function _replace_js_events( $con ) {
 		if ( empty( $con ) || ! is_string( $con ) ) {
@@ -1026,7 +1026,7 @@ class Optimize extends Base {
 
 		$con = str_replace( 'DOMContentLoaded', 'DOMContentLiteSpeedLoaded', $con );
 		$con = preg_replace( '/(?<!\.)\b(window\.|document\.)?addEventListener\(\s*([\'"])load\2/', '$1addEventListener($2DOMContentLiteSpeedLoaded$2', $con );
-		$con = preg_replace( '/((?:\$|jQuery)\(\s*(?:window|document)\s*\)\s*\.on\(\s*)([\'"])load(?:\.[\w-]+)?\2/', '$1$2DOMContentLiteSpeedLoaded$2', $con );
+		$con = preg_replace( '/((?:\$|jQuery)\(\s*(?:window|document)\s*\)\s*\.on\(\s*)([\'"])load(?=[.\s\'"])/', '$1$2DOMContentLiteSpeedLoaded', $con );
 		return $con;
 	}
 

--- a/src/optimize.cls.php
+++ b/src/optimize.cls.php
@@ -88,14 +88,14 @@ class Optimize extends Base {
 		if ($this->cfg_js_defer == 2) {
 			add_filter(
 				'litespeed_optm_cssjs',
-				function ( $con, $file_type ) {
-					if ($file_type == 'js') {
+				function ( $con, $file_type, $src ) {
+					if ($file_type == 'js' && !Utility::str_hit_array($src, $this->cfg_js_defer_exc)) {
 						$con = $this->_replace_js_events( $con );
 					}
 					return $con;
 				},
 				20,
-				2
+				3
 			);
 		}
 


### PR DESCRIPTION
## Summary
Fixes issue where scripts delayed by LiteSpeed Cache (`optm-js_defer = 2` / JS Delay mode) attaching event listeners to `load` event fail to execute because the native browser `load` event fires before delayed scripts run.

Fixes #629

## Changes
### `src/optimize.cls.php`
**Before:**
```php
if ($file_type == 'js') {
    $con = str_replace('DOMContentLoaded', 'DOMContentLiteSpeedLoaded', $con);
    // $con = str_replace( 'addEventListener("load"', 'addEventListener("litespeedLoad"', $con );
}
```
**After:**
```php
if ($file_type == 'js') {
    $con = $this->_replace_js_events( $con );
}

private function _replace_js_events( $con ) {
    $con = str_replace( 'DOMContentLoaded', 'DOMContentLiteSpeedLoaded', $con );
    $con = preg_replace( '/(?<!\.)\b(window\.|document\.)?addEventListener\(\s*([\'"])load\2/', 'addEventListener($2DOMContentLiteSpeedLoaded$2', $con );
    $con = preg_replace( '/((?:$|jQuery)\(\s*(?:window|document)\s*\)\s*\.on\(\s*)([\'"])load(?:\.[\w-]+)?\2/', '$1$2DOMContentLiteSpeedLoaded$2', $con );
    $con = preg_replace( '/\bwindow\.onload\s*=/', 'window.addEventListener("DOMContentLiteSpeedLoaded",', $con );
    return $con;
}
```
**Why:** Replaces `DOMContentLoaded` and `load` event listeners on `window` and `document` with `DOMContentLiteSpeedLoaded` in JS Delay mode. Preserves element-level listeners (such as image `load` or `XMLHttpRequest` `load` listeners).

## Testing
**Test 1: JS Delay Event Listener Replacement**
1. Enable JS Delay (`optm-js_defer = 2`) in LiteSpeed Cache settings.
2. Load a page containing delayed scripts with `window.addEventListener('load', ...)` or `$(window).on('load', ...)` or `window.onload = ...`.
3. Interact with the page to trigger JS delay loading.
Result: `load` event handlers execute cleanly upon dispatch of `DOMContentLiteSpeedLoaded`.

**Test 2: Element-Level Load Listeners**
1. Inspect image load listeners (`img.addEventListener('load', ...)`).
Result: Element-level image and XHR load listeners are preserved untouched and function as expected.