### PR TITLE
fix(object-cache): add support for igbinary serialization

### DIFF
--- a/src/object-cache-wp.cls.php
+++ b/src/object-cache-wp.cls.php
@@ -436,8 +436,21 @@ class WP_Object_Cache {
 		}
 
 		if ( ! $this->_object_cache->is_non_persistent( $group ) ) {
-			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
-			$this->_object_cache->set( $id, serialize( [ 'data' => $data ] ), (int) $expire );
+			if ( function_exists( 'igbinary_serialize' ) ) {
+				try {
+					$v = igbinary_serialize( [ 'data' => $data ] );
+				} catch ( \Throwable $e ) {
+					$v = false;
+				}
+				if ( false === $v || null === $v ) {
+					// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+					$v = serialize( [ 'data' => $data ] );
+				}
+			} else {
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+				$v = serialize( [ 'data' => $data ] );
+			}
+			$this->_object_cache->set( $id, $v, (int) $expire );
 			++$this->count_set;
 		}
 
@@ -509,7 +522,17 @@ class WP_Object_Cache {
 			$v = $this->_object_cache->get( $id, $group );
 
 			if ( false !== $v ) {
-				$v = maybe_unserialize( $v );
+				if ( is_string( $v ) && function_exists( 'igbinary_unserialize' ) && ! is_serialized( $v ) ) {
+					try {
+						// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+						$v_unserialized = @igbinary_unserialize( $v );
+					} catch ( \Throwable $e ) {
+						$v_unserialized = false;
+					}
+					$v = ( false !== $v_unserialized && null !== $v_unserialized ) ? $v_unserialized : maybe_unserialize( $v );
+				} else {
+					$v = maybe_unserialize( $v );
+				}
 			}
 
 			// To be compatible with false val.


### PR DESCRIPTION
## Summary
Adds support for the `igbinary` PHP extension in `WP_Object_Cache`. When `igbinary` is installed, object cache payloads are serialized using compact binary data (`igbinary_serialize`), reducing memory footprint and serialization overhead in Redis and Memcached.
Fixes #907

## Changes
### `src/object-cache-wp.cls.php`
**Before:**
```php
if ( ! $this->_object_cache->is_non_persistent( $group ) ) {
	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
	$this->_object_cache->set( $id, serialize( [ 'data' => $data ] ), (int) $expire );
	++$this->count_set;
}

if ( false !== $v ) {
	$v = maybe_unserialize( $v );
}
```
**After:**
```php
if ( ! $this->_object_cache->is_non_persistent( $group ) ) {
	if ( function_exists( 'igbinary_serialize' ) ) {
		$v = igbinary_serialize( [ 'data' => $data ] );
		if ( false === $v ) {
			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
			$v = serialize( [ 'data' => $data ] );
		}
	} else {
		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
		$v = serialize( [ 'data' => $data ] );
	}
	$this->_object_cache->set( $id, $v, (int) $expire );
	++$this->count_set;
}

if ( false !== $v ) {
	if ( is_string( $v ) && function_exists( 'igbinary_unserialize' ) && ! is_serialized( $v ) ) {
		try {
			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
			$v_unserialized = @igbinary_unserialize( $v );
		} catch ( \Throwable $e ) {
			$v_unserialized = false;
		}
		$v = ( false !== $v_unserialized ) ? $v_unserialized : maybe_unserialize( $v );
	} else {
		$v = maybe_unserialize( $v );
	}
}
```
**Why:** Uses `igbinary_serialize` when available for faster binary serialization, while maintaining full fallback compatibility with `maybe_unserialize` for legacy PHP serialized cache entries.

## Testing
**Test 1: Object cache write and read with igbinary**
1. Enable Redis/Memcached object cache on a server with `igbinary` extension installed.
2. Store and retrieve values via `wp_cache_set()` and `wp_cache_get()`.
Result: Values are serialized as binary igbinary payloads and read back accurately.

**Test 2: Backward compatibility with standard PHP serialize**
1. Read existing cache keys stored with standard PHP `serialize()`.
Result: `is_serialized()` detects standard PHP format and safely falls back to `maybe_unserialize()`.