### PR TITLE
fix(guest): prevent vary cookie mismatch under scoped debug log

### DIFF
--- a/lib/guest.cls.php
+++ b/lib/guest.cls.php
@@ -22,6 +22,8 @@ class Guest {
 	const O_CACHE_LOGIN_COOKIE = 'cache-login_cookie';
 	const O_DEBUG              = 'debug';
 	const O_DEBUG_IPS          = 'debug-ips';
+	const O_DEBUG_INC          = 'debug-inc';
+	const O_DEBUG_EXC          = 'debug-exc';
 	const O_UTIL_NO_HTTPS_VARY = 'util-no_https_vary';
 
 	/**
@@ -99,14 +101,28 @@ class Guest {
 		}
 
 		// Send vary cookie
-		$vary = 'guest_mode:1';
-		if ( $this->_conf && empty( $this->_conf[ self::O_DEBUG ] ) ) {
+		$vary     = 'guest_mode:1';
+		$is_debug = false;
+		if ( ! empty( $this->_conf[ self::O_DEBUG ] ) ) {
+			if ( 2 === (int) $this->_conf[ self::O_DEBUG ] ) {
+				$debug_ips = ! empty( $this->_conf[ self::O_DEBUG_IPS ] ) ? $this->_conf[ self::O_DEBUG_IPS ] : [];
+				$is_debug  = $this->ip_access( $debug_ips );
+			} elseif ( 1 === (int) $this->_conf[ self::O_DEBUG ] ) {
+				$is_debug = true;
+			}
+		}
+
+		if ( $is_debug && ( ! empty( $this->_conf[ self::O_DEBUG_INC ] ) || ! empty( $this->_conf[ self::O_DEBUG_EXC ] ) ) ) {
+			$is_debug = false;
+		}
+
+		if ( ! $is_debug && ! empty( $this->_conf[ self::HASH ] ) ) {
 			$vary = md5( $this->_conf[ self::HASH ] . $vary );
 		}
 
 		$expire = time() + 2 * 86400;
 		$is_ssl = ! empty( $this->_conf[ self::O_UTIL_NO_HTTPS_VARY ] ) ? false : $this->is_ssl();
-		setcookie( self::$_vary_name, $vary, $expire, '/', false, $is_ssl, true );
+		setcookie( self::$_vary_name, $vary, $expire, '/', '', $is_ssl, true );
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- No WP available
 		echo json_encode( [ 'reload' => 'yes' ] );
@@ -319,9 +335,11 @@ class Guest {
 			$apache_headers = apache_request_headers();
 			$_ip            = ! empty( $apache_headers['True-Client-IP'] ) ? $apache_headers['True-Client-IP'] : false;
 			if ( ! $_ip ) {
-				$_ip = ! empty( $apache_headers['X-Forwarded-For'] ) ? $apache_headers['X-Forwarded-For'] : false;
-				$_ip = explode( ',', $_ip );
-				$_ip = $_ip[0];
+				$raw_ip = ! empty( $apache_headers['X-Forwarded-For'] ) ? $apache_headers['X-Forwarded-For'] : false;
+				if ( $raw_ip ) {
+					$parts = explode( ',', $raw_ip );
+					$_ip   = $parts[0];
+				}
 			}
 		}
 

--- a/src/activation.cls.php
+++ b/src/activation.cls.php
@@ -415,6 +415,9 @@ class Activation extends Base {
 			$this_ids = [
 				self::HASH,
 				self::O_CACHE_LOGIN_COOKIE,
+				self::O_DEBUG,
+				self::O_DEBUG_INC,
+				self::O_DEBUG_EXC,
 				self::O_DEBUG_IPS,
 				self::O_UTIL_NO_HTTPS_VARY,
 			];

--- a/src/crawler.cls.php
+++ b/src/crawler.cls.php
@@ -1263,7 +1263,13 @@ class Crawler extends Root {
 		if ( $this->conf( Base::O_GUEST ) ) {
 			$vary_name = $this->cls( 'Vary' )->get_vary_name();
 			$vary_val  = 'guest_mode:1';
-			if ( ! defined( 'LSCWP_LOG' ) ) {
+			$is_debug  = Base::VAL_ON === $this->conf( Base::O_DEBUG );
+
+			if ( $is_debug && ( $this->conf( Base::O_DEBUG_INC ) || $this->conf( Base::O_DEBUG_EXC ) ) ) {
+				$is_debug = false;
+			}
+
+			if ( ! $is_debug ) {
 				$vary_val = md5( $this->conf( Base::HASH ) . $vary_val );
 			}
 			$crawler_factors[ 'cookie:' . $vary_name ] = [

--- a/src/vary.cls.php
+++ b/src/vary.cls.php
@@ -561,8 +561,21 @@ class Vary extends Root {
 			$list[] = $key . ':' . $val;
 		}
 
-		$res = implode( ';', $list );
-		if ( defined( 'LSCWP_LOG' ) ) {
+		$res      = implode( ';', $list );
+		$is_debug = false;
+		$debug    = $this->conf( Base::O_DEBUG );
+
+		if ( Base::VAL_ON === $debug ) {
+			$is_debug = true;
+		} elseif ( Base::VAL_ON2 === $debug && $this->cls( 'Router' )->is_admin_ip() ) {
+			$is_debug = true;
+		}
+
+		if ( $is_debug && ( $this->conf( Base::O_DEBUG_INC ) || $this->conf( Base::O_DEBUG_EXC ) ) ) {
+			$is_debug = false;
+		}
+
+		if ( $is_debug ) {
 			return $res;
 		}
 		// Encrypt in production.


### PR DESCRIPTION
## Summary
Fixes a Guest Mode cache miss issue where the guest vary cookie value diverges between `guest.vary.php` and WordPress core rendering when Debug Log is active with URI includes/excludes or Admin IP restrictions. The vary calculation now evaluates client debug eligibility and URI scoping consistently across both execution contexts.

Fixes #1026

## Changes
### Configuration Persistence (`src/activation.cls.php`)
**Before:**
```php
if ( $options[ self::O_GUEST ] ) {
	$this_ids = [
		self::HASH,
		self::O_CACHE_LOGIN_COOKIE,
		self::O_DEBUG_IPS,
		self::O_UTIL_NO_HTTPS_VARY,
	];
	$ids = array_merge( $ids, $this_ids );
}
```
**After:**
```php
if ( $options[ self::O_GUEST ] ) {
	$this_ids = [
		self::HASH,
		self::O_CACHE_LOGIN_COOKIE,
		self::O_DEBUG,
		self::O_DEBUG_INC,
		self::O_DEBUG_EXC,
		self::O_DEBUG_IPS,
		self::O_UTIL_NO_HTTPS_VARY,
	];
	$ids = array_merge( $ids, $this_ids );
}
```
**Why:** Ensures `lib/guest.cls.php` can access the active debug configuration from `.litespeed_conf.dat` when Object Cache is disabled.

### Standalone Guest Handler (`lib/guest.cls.php`)
**Before:**
```php
$vary = 'guest_mode:1';
if ( $this->_conf && empty( $this->_conf[ self::O_DEBUG ] ) ) {
	$vary = md5( $this->_conf[ self::HASH ] . $vary );
}
```
**After:**
```php
$vary     = 'guest_mode:1';
$is_debug = false;
if ( ! empty( $this->_conf[ self::O_DEBUG ] ) ) {
	if ( 2 === (int) $this->_conf[ self::O_DEBUG ] ) {
		$debug_ips = ! empty( $this->_conf[ self::O_DEBUG_IPS ] ) ? $this->_conf[ self::O_DEBUG_IPS ] : [];
		$is_debug  = $this->ip_access( $debug_ips );
	} elseif ( 1 === (int) $this->_conf[ self::O_DEBUG ] ) {
		$is_debug = true;
	}
}

if ( $is_debug && ( ! empty( $this->_conf[ self::O_DEBUG_INC ] ) || ! empty( $this->_conf[ self::O_DEBUG_EXC ] ) ) ) {
	$is_debug = false;
}

if ( ! $is_debug && ! empty( $this->_conf[ self::HASH ] ) ) {
	$vary = md5( $this->_conf[ self::HASH ] . $vary );
}
```
**Why:** Prevents `guest.vary.php` from emitting an unhashed cookie when debug logging is restricted to specific URIs or non-matching client IPs.

### Core Vary Engine (`src/vary.cls.php`)
**Before:**
```php
$res = implode( ';', $list );
if ( defined( 'LSCWP_LOG' ) ) {
	return $res;
}
return md5( $this->conf( Base::HASH ) . $res );
```
**After:**
```php
$res      = implode( ';', $list );
$is_debug = false;
$debug    = $this->conf( Base::O_DEBUG );

if ( Base::VAL_ON === $debug ) {
	$is_debug = true;
} elseif ( Base::VAL_ON2 === $debug && $this->cls( 'Router' )->is_admin_ip() ) {
	$is_debug = true;
}

if ( $is_debug && ( $this->conf( Base::O_DEBUG_INC ) || $this->conf( Base::O_DEBUG_EXC ) ) ) {
	$is_debug = false;
}

if ( $is_debug ) {
	return $res;
}
return md5( $this->conf( Base::HASH ) . $res );
```
**Why:** Keeps the domain-wide vary cookie hashed consistently across all pages when URI scoping is enabled.

### Crawler Factors (`src/crawler.cls.php`)
**Before:**
```php
if ( ! defined( 'LSCWP_LOG' ) ) {
	$vary_val = md5( $this->conf( Base::HASH ) . $vary_val );
}
```
**After:**
```php
$is_debug = Base::VAL_ON === $this->conf( Base::O_DEBUG );
if ( $is_debug && ( $this->conf( Base::O_DEBUG_INC ) || $this->conf( Base::O_DEBUG_EXC ) ) ) {
	$is_debug = false;
}
if ( ! $is_debug ) {
	$vary_val = md5( $this->conf( Base::HASH ) . $vary_val );
}
```
**Why:** Aligns guest mode crawler factor vary hashing with the updated vary debug rules.

## Testing
**Test 1: Guest Mode ON + Debug Log ON + Debug URI Includes set**
1. Configure Guest Mode ON and Debug Log ON with Debug URI Includes set (`rest_route=/litespeed`).
2. Make a request to `guest.vary.php` and verify the cookie header value.
3. Reload `/` with the returned cookie header.
Result: Response returns `x-litespeed-cache: hit` on reload with no cookie overwrite.