### PR TITLE
fix(cache): cap wp-content/litespeed size with automatic oldest-first pruning (#777)

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -47,6 +47,7 @@ $litespeed_php_files = array(
 	'src/error.cls.php',
 	'src/esi.cls.php',
 	'src/file.cls.php',
+	'src/folder.cls.php',
 	'src/guest.cls.php',
 	'src/gui.cls.php',
 	'src/health.cls.php',

--- a/data/const.default.json
+++ b/data/const.default.json
@@ -162,6 +162,7 @@
 	"misc-heartbeat_back_ttl": "60",
 	"misc-heartbeat_editor": "",
 	"misc-heartbeat_editor_ttl": "15",
+	"misc-max_folder_size": "",
 	"cdn": "",
 	"cdn-attr": ".src\n.data-src\n.href\n.poster\nsource.srcset",
 	"cdn-ori": "",

--- a/readme.txt
+++ b/readme.txt
@@ -259,6 +259,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 8.0 - Coming soon 2026 =
 * 🌱**OptiMax** OptiMax to maximize the page score.
+* **Cache** Added a maximum cache folder size limit (wp-content/litespeed) with automatic oldest-first pruning to protect the disk from bot-traffic growth. (#777)
 
 = 7.9.1 - Aug 18 2026 =
 * **Core** Aligned the runtime PHP and WordPress guards with the published minimum requirements.

--- a/src/base.cls.php
+++ b/src/base.cls.php
@@ -264,6 +264,7 @@ class Base extends Root {
 	const O_MISC_HEARTBEAT_BACK_TTL   = 'misc-heartbeat_back_ttl';
 	const O_MISC_HEARTBEAT_EDITOR     = 'misc-heartbeat_editor';
 	const O_MISC_HEARTBEAT_EDITOR_TTL = 'misc-heartbeat_editor_ttl';
+	const O_MISC_MAX_FOLDER_SIZE      = 'misc-max_folder_size';
 
 	// -------------------------------------------------- ##
 	// --------------        CDN        ----------------- ##
@@ -550,6 +551,7 @@ class Base extends Root {
 		self::O_MISC_HEARTBEAT_BACK_TTL => 0,
 		self::O_MISC_HEARTBEAT_EDITOR => false,
 		self::O_MISC_HEARTBEAT_EDITOR_TTL => 0,
+		self::O_MISC_MAX_FOLDER_SIZE => 0,
 
 		// CDN
 		self::O_CDN => false,
@@ -1018,7 +1020,7 @@ class Base extends Root {
 	 * @return bool
 	 */
 	protected function _conf_cron( $id ) {
-		$check_ids = [ self::O_OPTM_CSS_ASYNC, self::O_MEDIA_PLACEHOLDER_RESP_ASYNC, self::O_DISCUSS_AVATAR_CRON, self::O_IMG_OPTM_AUTO, self::O_CRAWLER ];
+		$check_ids = [ self::O_OPTM_CSS_ASYNC, self::O_MEDIA_PLACEHOLDER_RESP_ASYNC, self::O_DISCUSS_AVATAR_CRON, self::O_IMG_OPTM_AUTO, self::O_CRAWLER, self::O_MISC_MAX_FOLDER_SIZE ];
 
 		return in_array( $id, $check_ids, true );
 	}

--- a/src/folder.cls.php
+++ b/src/folder.cls.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Cache folder size guard.
+ *
+ * @since      8.0
+ * @package    LiteSpeed
+ */
+
+namespace LiteSpeed;
+
+defined( 'WPINC' ) || exit();
+
+/**
+ * Enforce a maximum size for the regenerable cache-asset subdirs under
+ * wp-content/litespeed/. Triggered by WP cron via Task; the actual check runs
+ * oldest-first across the asset subdirs and prunes until the directory is
+ * under a 90% hysteresis target.
+ *
+ * @since 8.0
+ */
+class Folder extends Base {
+
+	const LOG_TAG = '[Folder]';
+
+	/**
+	 * Subdirs that hold regenerable cache assets and are safe to prune.
+	 *
+	 * @var string[]
+	 */
+	const ASSET_SUBDIRS = [ 'css', 'js', 'ucss', 'ccss', 'optimax', 'lqip', 'avatar', 'localres' ];
+
+	/**
+	 * Per-run cap to avoid hogging a single cron tick on pathological dirs.
+	 *
+	 * @var int
+	 */
+	const PER_RUN_DELETE_LIMIT = 5000;
+
+	/**
+	 * Cron entry point — measure asset subdirs and prune oldest-first when
+	 * over the configured size budget.
+	 *
+	 * @since 8.0
+	 */
+	public static function cron() {
+		$max_mb = (int) self::cls()->conf( self::O_MISC_MAX_FOLDER_SIZE );
+		if ( $max_mb <= 0 ) {
+			return;
+		}
+
+		if ( ! defined( 'LITESPEED_STATIC_DIR' ) || ! is_dir( LITESPEED_STATIC_DIR ) ) {
+			return;
+		}
+
+		$max_bytes = $max_mb * 1000000;
+
+		$entries = self::_collect_files();
+		if ( empty( $entries ) ) {
+			return;
+		}
+
+		$total = 0;
+		foreach ( $entries as $e ) {
+			$total += $e['size'];
+		}
+
+		$target = (int) ( $max_bytes * 0.9 );
+		if ( $total <= $target ) {
+			return;
+		}
+
+		usort( $entries, function ( $a, $b ) {
+			return $a['mtime'] <=> $b['mtime'];
+		} );
+
+		$over      = $total - $target;
+		$deleted   = 0;
+		$reclaimed = 0;
+		foreach ( $entries as $e ) {
+			if ( $over <= 0 || $deleted >= self::PER_RUN_DELETE_LIMIT ) {
+				break;
+			}
+			if ( ! is_file( $e['path'] ) ) {
+				continue;
+			}
+
+			wp_delete_file( $e['path'] );
+			if ( ! is_file( $e['path'] ) ) {
+				$over      -= $e['size'];
+				$reclaimed += $e['size'];
+				++$deleted;
+			}
+		}
+
+		if ( $deleted > 0 ) {
+			self::debug( sprintf(
+				'Pruned %d file(s) to enforce %d MB limit (reclaimed %s, total before %s).',
+				$deleted,
+				$max_mb,
+				Utility::real_size( $reclaimed ),
+				Utility::real_size( $total )
+			) );
+
+			// Recreate .htaccess if all asset files were wiped.
+			File::ensure_static_protection();
+		}
+	}
+
+	/**
+	 * Walk the regenerable asset subdirs and collect file metadata for
+	 * size accounting and prune ordering. Multisite-safe (walks per-blog
+	 * subfolders via the recursive iterator).
+	 *
+	 * @since 8.0
+	 *
+	 * @return array<int,array{path:string,mtime:int,size:int}>
+	 */
+	private static function _collect_files() {
+		$entries = [];
+
+		foreach ( self::ASSET_SUBDIRS as $subdir ) {
+			$base = LITESPEED_STATIC_DIR . '/' . $subdir;
+			if ( ! is_dir( $base ) ) {
+				continue;
+			}
+
+			try {
+				$iter = new \RecursiveIteratorIterator(
+					new \RecursiveDirectoryIterator( $base, \FilesystemIterator::SKIP_DOTS ),
+					\RecursiveIteratorIterator::LEAVES_ONLY,
+					\RecursiveIteratorIterator::CATCH_GET_CHILD
+				);
+			} catch ( \Throwable $e ) {
+				self::debug( 'Skip unreadable subdir [subdir] ' . $subdir );
+				continue;
+			}
+
+			try {
+				foreach ( $iter as $file ) {
+					if ( ! $file->isFile() ) {
+						continue;
+					}
+					$entries[] = [
+						'path'  => $file->getPathname(),
+						'mtime' => $file->getMTime(),
+						'size'  => (int) $file->getSize(),
+					];
+				}
+			} catch ( \Throwable $e ) {
+				self::debug( 'Aborted walking subdir [subdir] ' . $subdir );
+			}
+		}
+
+		return $entries;
+	}
+}

--- a/src/lang.cls.php
+++ b/src/lang.cls.php
@@ -249,6 +249,7 @@ class Lang extends Base {
 			self::O_MISC_HEARTBEAT_BACK_TTL   => __( 'Backend Heartbeat TTL', 'litespeed-cache' ),
 			self::O_MISC_HEARTBEAT_EDITOR     => __( 'Editor Heartbeat', 'litespeed-cache' ),
 			self::O_MISC_HEARTBEAT_EDITOR_TTL => __( 'Editor Heartbeat TTL', 'litespeed-cache' ),
+			self::O_MISC_MAX_FOLDER_SIZE      => __( 'Maximum Cache Folder Size', 'litespeed-cache' ),
 
 			self::O_CDN                   => __( 'Use CDN Mapping', 'litespeed-cache' ),
 			self::CDN_MAPPING_URL         => __( 'CDN URL', 'litespeed-cache' ),

--- a/src/task.cls.php
+++ b/src/task.cls.php
@@ -68,6 +68,10 @@ class Task extends Root {
 			'name' => 'litespeed_task_crawler',
 			'hook' => 'LiteSpeed\Crawler::start_async_cron',
 		], // Set crawler to last one to use above results
+		Base::O_MISC_MAX_FOLDER_SIZE => [
+			'name' => 'litespeed_task_folder_size',
+			'hook' => 'LiteSpeed\Folder::cron',
+		],
 	];
 
 	/**

--- a/tpl/cache/settings-purge.tpl.php
+++ b/tpl/cache/settings-purge.tpl.php
@@ -155,4 +155,18 @@ $break_arr = array(
 		</td>
 	</tr>
 
+	<tr>
+		<th>
+			<?php $option_id = Base::O_MISC_MAX_FOLDER_SIZE; ?>
+			<?php $this->title( $option_id ); ?>
+		</th>
+		<td>
+			<?php $this->build_input( $option_id, 'litespeed-input-short' ); ?> <?php esc_html_e( 'MB', 'litespeed-cache' ); ?>
+			<div class="litespeed-desc">
+				<?php esc_html_e( 'Maximum total size of the regenerable cache files under wp-content/litespeed/. When exceeded, the oldest files are removed automatically. 0 disables this limit.', 'litespeed-cache' ); ?>
+			</div>
+			<?php $this->_validate_ttl( $option_id, 1, 100000, true ); ?>
+		</td>
+	</tr>
+
 </tbody></table>


### PR DESCRIPTION
## Summary
New site-level setting **Maximum Cache Folder Size (MB)** under Cache -> Purge. When set > 0, a 15-min cron task measures the regenerable asset subdirs (css, js, ucss, ccss, optimax, lqip, avatar, localres) and prunes the oldest files until the tree is at 90% of the configured cap. Default 0 keeps the cron as a no-op, so existing installs are unaffected. Fixes #777.

## Changes
### src/folder.cls.php (new)
**Before:** No automated protection. wp-content/litespeed grows unbounded under aggressive bot traffic (WooCommerce filter URL combinations in the repro), eventually filling the disk.
**After:** Static cron callback that walks the asset subdirs with a RecursiveIteratorIterator, sums sizes, and when over budget deletes oldest files first via wp_delete_file, capped at 5000 files per run to avoid hogging a single tick.
**Why:** Issue #777 asks for a cap. The hot path (File::save) cannot run a recursive scan per write, so enforcement lives in a low-frequency cron. 90% hysteresis prevents thrash. 5000-file per-run cap resumes on the next tick instead of stalling cron.

### src/task.cls.php
**Before:** No cron entry for folder size.
**After:** Adds 'litespeed_task_folder_size' to the triggers map, hooked to LiteSpeed\Folder::cron on the standard 15-min 'litespeed_filter' schedule. Task::try_clean clears the schedule when the setting goes back to 0.
**Why:** Reuses the existing 15-min cron infrastructure; the trigger map pattern is used by every other recurring task in the plugin.

### src/base.cls.php
**Before:** No option id for the new setting.
**After:** Adds O_MISC_MAX_FOLDER_SIZE const, default 0 in the site-level options array, and the new id in _conf_cron check_ids so saves propagate to Task::try_clean.
**Why:** Setting registration chain (const -> default -> check_ids) is the established pattern in this file.

### tpl/cache/settings-purge.tpl.php
**Before:** No UI for the new setting.
**After:** Adds an MB input row before the closing </tbody>, mirroring the existing O_DEBUG_FILESIZE MB-input pattern. Includes description and _validate_ttl range guard (1-100000).
**Why:** Cache -> Purge tab is the right home for size-driven purge controls.

### data/const.default.json
**Before:** No default for the new id.
**After:** Empty-string default so first-install reads the site-level default (0).
**Why:** Required by the Conf auto-sync flow.

### src/lang.cls.php
**Before:** No title.
**After:** 'Maximum Cache Folder Size' label.
**Why:** Required by the title() helper.

### autoload.php
**Before:** src/folder.cls.php not in the require list.
**After:** Added between file.cls.php and guest.cls.php, alphabetical order.
**Why:** autoload.php hardcodes the require_once list and the spl_autoload fallback only handles thirdparty/. Without this entry, the new class would not be loaded and the cron callback would fatal.

### readme.txt
**Before:** No 8.0 changelog entry.
**After:** Bullet under '= 8.0 - Coming soon 2026 =' describing the limit and oldest-first pruning.
**Why:** Discoverability for the feature and a clear signal for the maintainer during release.

## Testing
**Test 1: setting UI shows up**
1. Go to LiteSpeed Cache -> Cache -> Purge.
2. Confirm 'Maximum Cache Folder Size' row with empty input and the description text.
Result: row renders, persists.

**Test 2: disabled (default) is a no-op**
1. Leave the field empty, save.
2. wp cron event list shows no litespeed_task_folder_size.
3. wp-content/litespeed/ size is unaffected.
Result: BC preserved.

**Test 3: enabled triggers oldest-first prune**
1. Enable CSS/JS Combine and UCSS, visit a few pages to grow css/js/ucss.
2. Set Maximum Cache Folder Size to 1 (MB), save.
3. Run wp cron event run litespeed_task_folder_size.
4. du -sb wp-content/litespeed/ is now under ~900 KB.
5. Debug log shows '[Folder] Pruned N file(s) to enforce 1 MB limit (...).
Result: works as expected.

**Test 4: disable clears the schedule**
1. Set the field back to 0, save.
2. wp cron event list no longer lists litespeed_task_folder_size.
Result: works as expected.

**Test 5: bot-traffic simulation (original repro from #777)**
1. Set the field to 5 MB.
2. Hit the site with a parameter sweep (?filter_color=red, ?filter_color=blue, ...).
3. css/js/ucss subdirs stay under the cap; the cron reclaims oldest files.
Result: works as expected.

**Test 6: phpcs**
vendor/bin/phpcs --standard=phpcs.ruleset.xml --no-cache autoload.php src/folder.cls.php src/task.cls.php src/base.cls.php src/lang.cls.php tpl/cache/settings-purge.tpl.php
Result: 0 errors, 0 warnings.