### PR TITLE
Exclude WordPress core hooks/i18n from JS defer (inline translations call wp.i18n synchronously)

### DIFF
--- a/data/js_defer_excludes.txt
+++ b/data/js_defer_excludes.txt
@@ -12,3 +12,7 @@ _stq
 # Cloudflare turnstile - Tobolo
 turnstile
 challenges.cloudflare.com
+
+# WordPress core hooks/i18n: inline `wp-i18n-js-after` and `*-js-translations` blocks call wp.i18n.setLocaleData() synchronously on every localized site - Tobolo
+wp-includes/js/dist/hooks
+wp-includes/js/dist/i18n

--- a/data/js_excludes.txt
+++ b/data/js_excludes.txt
@@ -15,6 +15,8 @@ cse.google.com/cse.js
 /syntaxhighlighter/
 spotlight-social-photo-feeds ## https://docs.spotlightwp.com/article/757-autoptimize-compatibility @Tobolo
 userway.org
+wp-includes/js/dist/hooks ## WordPress core, keep out of combined files so the defer exclude in js_defer_excludes.txt can match - Tobolo
+wp-includes/js/dist/i18n ## see js_defer_excludes.txt
 
 # Inline JS excludes
 document.write


### PR DESCRIPTION
## What

Adds `wp-includes/js/dist/hooks` and `wp-includes/js/dist/i18n` to the predefined **JS Deferred / Delayed Excludes**, and to the predefined **JS Excludes** so the two files are not swallowed into a combined file where the defer exclude could no longer match.

## Why

On every localized site WordPress core prints inline scripts that call `wp.i18n.setLocaleData()` synchronously: `wp-i18n-js-after` plus one `<handle>-js-translations` block for each script that ships translations (Contact Form 7, WooCommerce, Elementor, block scripts, ...).

With **Load JS Deferred = Deferred** the external `i18n.min.js` / `hooks.min.js` get `defer`, while those inline blocks still run immediately during parsing (inline JS is not deferred in Deferred mode). The result on every page load is

```
Uncaught ReferenceError: wp is not defined
    source: wp-i18n-js-after, contact-form-7-js-translations, wp-a11y-js-translations, ...
```

This reproduces deterministically across many sites on LSCWP 7.9 with Deferred enabled; adding the two files to the site-level excludes removes the errors. `hooks` is a dependency of `i18n`. Both files are tiny (about 2 KB and 5 KB minified), so keeping them synchronous has no measurable cost, unlike excluding jQuery, which should stay a per-site decision.

## Notes

- Partial strings without the `.min.js` suffix also cover the `SCRIPT_DEBUG` variants (`hooks.js`, `i18n.js`).
- `a11y` needs no entry: its inline block only calls `wp.i18n`.
- Same pattern as the existing Turnstile entries, which are also present in both lists.
